### PR TITLE
Allow logging in with a different account, and introduce closeable errorviews

### DIFF
--- a/example/src/SampleApp/SampleApp.tsx
+++ b/example/src/SampleApp/SampleApp.tsx
@@ -164,6 +164,14 @@ function SampleApp() {
                                                                     authController
                                                                 }) => {
 
+
+        
+        // use example for testing close button on ErrorView
+        if(user?.email?.includes('test1@test.com')) {
+            return false
+        }
+        
+
         if(user?.email?.includes("flanders")){
             throw Error("Stupid Flanders!");
         }

--- a/src/core/components/ErrorView.tsx
+++ b/src/core/components/ErrorView.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import clsx from "clsx";
 import ErrorIcon from "@mui/icons-material/Error";
-import { Theme, Tooltip } from "@mui/material";
+import Close from "@mui/icons-material/Close";
+import { Box, Theme, Tooltip } from "@mui/material";
 
 import createStyles from "@mui/styles/createStyles";
 import makeStyles from "@mui/styles/makeStyles";
@@ -17,7 +18,11 @@ export const useStyles = makeStyles((theme: Theme) =>
         },
         text: {
             paddingLeft: theme.spacing(2)
-        }
+        },
+        flexEnd: {
+            display:"flex",
+            justifyContent:"flex-end"
+        },
     })
 );
 
@@ -26,7 +31,8 @@ export const useStyles = makeStyles((theme: Theme) =>
  */
 export interface ErrorViewProps {
     error: string,
-    tooltip?: string
+    tooltip?: string,
+    closeFn?: ()=>void;
 }
 
 /**
@@ -39,12 +45,14 @@ export interface ErrorViewProps {
  */
 export function ErrorView({
                               error,
-                              tooltip
+                              tooltip,
+                              closeFn,
                           }: ErrorViewProps): React.ReactElement {
     const classes = useStyles();
     const body = (
         <div
-            className={clsx(classes.flexCenter, classes.smallMargin)}>
+            className={clsx(classes.flexCenter, classes.smallMargin)}
+        >
             <ErrorIcon fontSize={"small"} color={"error"}/>
             <div className={classes.text}>{error}</div>
         </div>
@@ -56,6 +64,22 @@ export function ErrorView({
                 {body}
             </Tooltip>
         );
+    }
+
+    if(closeFn) {
+        return (
+            <Box sx={{border:1, borderColor: 'info.main', borderRadius:1}}>
+                <div>
+                    <div
+                        className={clsx(classes.flexEnd, classes.smallMargin)}
+                        onClick={closeFn}
+                    >
+                        <Close fontSize="small" color="info" />
+                    </div>
+                    {body}
+                </div>
+            </Box>
+        )
     }
     return body;
 }

--- a/src/core/internal/useBuildAuthController.tsx
+++ b/src/core/internal/useBuildAuthController.tsx
@@ -34,6 +34,9 @@ export function useBuildAuthController<UserType>({
 
     const authenticationEnabled = authentication === undefined || !!authentication;
     const canAccessMainView = (!authenticationEnabled || Boolean(user) || Boolean(loginSkipped)) && !notAllowedError;
+    const clearNotAllowedError = () => {
+        setNotAllowedError(false);
+    }
 
     const authController: AuthController<UserType> = useMemo(() => ({
         user,
@@ -45,13 +48,17 @@ export function useBuildAuthController<UserType>({
         signOut: authDelegate.signOut,
         extra,
         setExtra,
-        authDelegate
+        authDelegate,
+        clearNotAllowedError
     }), [authDelegate, authLoading, canAccessMainView, extra, loginSkipped, notAllowedError, user]);
+
+   
 
     const checkAuthentication = useCallback(async () => {
         const delegateUser = authDelegate.user;
         if (authentication instanceof Function && delegateUser) {
             setAuthLoading(true);
+            setNotAllowedError(false);
             try {
                 const allowed = await authentication({
                     user: delegateUser,

--- a/src/firebase_app/components/FirebaseLoginView.tsx
+++ b/src/firebase_app/components/FirebaseLoginView.tsx
@@ -169,6 +169,7 @@ export function FirebaseLoginView({
                     {notAllowedMessage &&
                     <Box p={2}>
                         <ErrorView
+                            closeFn={authController.clearNotAllowedError}
                             error={notAllowedMessage}/>
                     </Box>}
 

--- a/src/models/auth.tsx
+++ b/src/models/auth.tsx
@@ -69,6 +69,12 @@ export interface AuthController<UserType extends User = User> {
      */
     authDelegate: AuthDelegate<UserType>;
 
+    /**
+     *  
+     * Clears NotAllowed error in the case that user wants to try using a different user.
+     */
+     clearNotAllowedError: () => void;
+
 }
 
 /**


### PR DESCRIPTION
Fixes a bug on login, and exposes new `closeFn` prop to allow for closeable errorviews.

Steps to replicate bug on login without this PR:

1. login a user that would throw an Error / return false on the `Authenticator` function like this:

```ts
const myAuthenticator: Authenticator<FirebaseUser> = async ({
                                                                    user,
                                                                    authController
                                                                }) => {        
        // use example for testing close button on ErrorView
        if(user?.email?.includes('test1@test.com')) {
            return false
        }
        

       return true
    };
 ```
2. try to login a user that won't throw an error
