### PR TITLE
added previewUrl prop in storage options

### DIFF
--- a/packages/firecms_core/src/preview/PropertyPreview.tsx
+++ b/packages/firecms_core/src/preview/PropertyPreview.tsx
@@ -87,10 +87,11 @@ export const PropertyPreview = React.memo(function PropertyPreview<T extends CMS
                                              url={value}
                                              previewType={stringProperty.url}/>;
             } else if (stringProperty.storage) {
+                const filePath = stringProperty.storage.previewUrl ? stringProperty.storage.previewUrl(value) : value;
                 content = <StorageThumbnail
                     storeUrl={property.storage?.storeUrl ?? false}
                     size={props.size}
-                    storagePathOrDownloadUrl={value}/>;
+                    storagePathOrDownloadUrl={filePath}/>;
             } else if (stringProperty.markdown) {
                 content = <Markdown source={value}/>;
             } else {

--- a/packages/firecms_core/src/types/properties.ts
+++ b/packages/firecms_core/src/types/properties.ts
@@ -772,6 +772,11 @@ export type StorageConfig = {
      */
     postProcess?: (pathOrUrl: string) => Promise<string>;
 
+    /**
+     * You can use this prop in order to provide a custom preview URL.
+     * Useful when the file's path is different from the original field value
+     */
+    previewUrl?: (fileName: string) => string;
 }
 
 /**


### PR DESCRIPTION
You can use this prop in order to provide a custom preview URL.
Useful when the file's path is different from the original field value