### PR TITLE
fix: Fix for XLSX security issue CVE-2024-22363

### DIFF
--- a/packages/data_import_export/package.json
+++ b/packages/data_import_export/package.json
@@ -12,7 +12,7 @@
     "@firecms/formex": "^3.0.0-canary.77",
     "@firecms/schema_inference": "^3.0.0-canary.77",
     "@firecms/ui": "^3.0.0-canary.77",
-    "xlsx": "^0.18.5"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
   },
   "peerDependencies": {
     "firebase": "^10.12.2",


### PR DESCRIPTION
The XLSX package has a critical security issue, mentioned here: https://github.com/advisories/GHSA-5pgg-2g8v-p4x9.

Unfortunately, the package is out of NPM and it's managed now via a repo installation.