### PR TITLE
docs: updated the docs of a custom storage with a simple S3 Custom St…

### DIFF
--- a/website/docs/pro/custom_storage.mdx
+++ b/website/docs/pro/custom_storage.mdx
@@ -14,95 +14,110 @@ This guide will help you set up a custom storage solution.
 A custom storage source in FireCMS is defined by implementing the `StorageSource` interface.
 Here is a template for creating a custom storage source.
 
+Beware: This is an example on how you can implement and use S3, directly from a custom storage source.
+This is not the preferred way of using S3 since it'd discourage to consume it directly from the frontend.
+As you will have to insert the API key and secret in the frontend, which is not secure.
+Instead, you could use [Amplify/Storage](https://docs.amplify.aws/react/build-a-backend/storage/) or a custom IAM auth.
+
+
 Below is a template for creating a custom storage source:
 
 ```tsx
-import { StorageSource, UploadFileProps, UploadFileResult, DownloadConfig } from "@firecms/core";
+import {StorageSource, UploadFileProps, UploadFileResult, DownloadConfig} from "@firecms/core";
+import {S3Client, PutObjectCommand, GetObjectCommand} from "@aws-sdk/client-s3";
+import {getSignedUrl} from "@aws-sdk/s3-request-presigner";
 
-export interface CustomStorageSourceProps {
-  // Define the necessary configuration properties for your storage solution
-  apiKey?: string;
-  apiSecret?: string;
-  region?: string;
-  bucketName?: string;
-  // ... other necessary properties
+export interface S3StorageSourceProps {
+  apiKey: string;
+  apiSecret: string;
+  region: string;
+  defaultBucket?: string;
 }
 
-export function useCustomStorageSource(props: CustomStorageSourceProps): StorageSource {
-
-  // Initialize your storage client based on the props provided
-  // For example, it could be a client for Amazon S3, Google Cloud Storage, etc.
-  const customClient = initializeCustomClient(props);
+function initializeCustomClient({apiKey, apiSecret, region, defaultBucket}: S3StorageSourceProps) {
+  const s3Client = new S3Client({region, credentials: {accessKeyId: apiKey, secretAccessKey: apiSecret}});
 
   return {
-    async uploadFile({ file, fileName, path, metadata, bucket }: UploadFileProps): Promise<UploadFileResult> {
-      const usedFilename = fileName ?? file.name;
-      const destinationPath = `${path}/${usedFilename}`;
-      const targetBucket = bucket ?? props.bucketName;
-
-      // Logic to upload file using your storage client
-      await customClient.uploadFile(targetBucket, destinationPath, file, metadata);
-
-      return { path: destinationPath, bucket: targetBucket };
-    },
-
-    async getFile(path: string, bucket?: string): Promise<File | null> {
-      const targetBucket = bucket ?? props.bucketName;
-
-      try {
-        // Logic to retrieve the file using your storage client
-        const fileData = await customClient.getFile(targetBucket, path);
-
-        if (fileData) {
-          const blob = new Blob([fileData], { type: fileData.type });
-          return new File([blob], path);
-        } else {
-          return null;
-        }
-      } catch (e) {
-        if (e.message === "File not found") {
-          return null; // File not found
-        }
-        throw e;
+    uploadFile: async (destinationPath: string, file: File, bucket?: string, metadata?: any) => {
+      await s3Client.send(new PutObjectCommand({
+        Bucket: bucket || defaultBucket,
+        Key: destinationPath,
+        Body: file,
+        ContentType: metadata?.contentType,
+        Metadata: metadata
+      }));
+      return {
+        path: destinationPath,
+        bucket: bucket || defaultBucket || ""
       }
     },
-
-    async getDownloadURL(path: string, bucket?: string): Promise<DownloadConfig> {
-      const targetBucket = bucket ?? props.bucketName;
-
-      try {
-        // Logic to get the download URL using your storage client
-        const url = await customClient.getDownloadURL(targetBucket, path);
-        const metadata = await customClient.getMetadata(targetBucket, path);
-        return { url, metadata };
-      } catch (e) {
-        if (e.message === "File not found") {
-          return { url: null, fileNotFound: true };
-        }
-        throw e;
+    getFile: async (path: string, bucket?: string) => {
+      return await s3Client.send(new GetObjectCommand({
+        Bucket: bucket || defaultBucket || "",
+        Key: path
+      }));
+    },
+    getDownloadURL: async (path: string, bucket?: string) => {
+      const command = new GetObjectCommand({Bucket: bucket || defaultBucket, Key: path});
+      return await getSignedUrl(s3Client, command, {expiresIn: 3600});
+    },
+    getMetadata: async (path: string, bucket?: string) => {
+      const s3Object = await s3Client.send(new GetObjectCommand({
+        Bucket: bucket || defaultBucket,
+        Key: path
+      }));
+      return {
+        bucket: (bucket || defaultBucket) ?? "",
+        fullPath: path,
+        name: path,
+        size: s3Object.ContentLength || 0,
+        contentType: s3Object.ContentType || "",
+        customMetadata: s3Object.Metadata || {}
       }
     }
   };
 }
 
-// Example initialize function
-function initializeCustomClient({ apiKey, apiSecret, region, bucketName }: CustomStorageSourceProps) {
-  // Initialization logic for your storage client
+export function useCustomStorageSource(props: S3StorageSourceProps): StorageSource {
+  // Initialize your storage client based on the props provided
+  // For example, it could be a client for Amazon S3, Google Cloud Storage, etc.
+  const customClient = initializeCustomClient(props);
+
   return {
-    uploadFile: async (bucket: string, destinationPath: string, file: File, metadata?: any) => {
-      // Implement upload logic
+    async uploadFile({file, fileName, path, metadata, bucket}: UploadFileProps): Promise<UploadFileResult> {
+      const usedFilename = fileName ?? file.name;
+      const destinationPath = `${path}/${usedFilename}`;
+      // Logic to upload file using your storage client
+      return await customClient.uploadFile(destinationPath, file, bucket, metadata);
     },
-    getFile: async (bucket: string, path: string) => {
-      // Implement get file logic
-      return null; // Replace with actual file data
+
+    async getFile(path: string, bucket?: string): Promise<File | null> {
+      const targetBucket = bucket ?? props.defaultBucket;
+      try {
+        // Logic to retrieve the file using your storage client
+        const fileData = await customClient.getFile(path, targetBucket);
+        if (fileData && fileData.Body) {
+          const byteArray = await fileData.Body.transformToByteArray();
+          const blob = new Blob([byteArray], {type: fileData.ContentType});
+          return new File([blob], path);
+        } else {
+          return null;
+        }
+      } catch (e) {
+        return null; // File not found
+      }
     },
-    getDownloadURL: async (bucket: string, path: string) => {
-      // Implement get download URL logic
-      return ""; // Replace with actual URL
-    },
-    getMetadata: async (bucket: string, path: string) => {
-      // Implement get metadata logic
-      return {}; // Replace with actual metadata
+
+    async getDownloadURL(path: string, bucket?: string): Promise<DownloadConfig> {
+      const targetBucket = bucket || props.defaultBucket;
+      try {
+        // Logic to get the download URL using your storage client
+        const url = await customClient.getDownloadURL(path, targetBucket);
+        const metadata = await customClient.getMetadata(path, targetBucket);
+        return {url, metadata};
+      } catch (e) {
+        return {url: null, fileNotFound: true};
+      }
     }
   };
 }
@@ -114,7 +129,7 @@ After creating the custom storage source, you can use it in your FireCMS applica
 
 ### Example Usage
 
-Here is an example of how to use the custom storage source in your FireCMS application:
+Here is an example of how to use the custom storage source in your FireCMS application
 
 ```tsx
 import React from "react";
@@ -143,7 +158,7 @@ const customStorageConfig: CustomStorageSourceProps = {
   apiKey: "your-api-key",
   apiSecret: "your-api-secret",
   region: "your-region",
-  bucketName: "your-bucket-name"
+  defaultBucket: "your-bucket-name"
   // ... other necessary properties
 };
 
@@ -202,6 +217,34 @@ const CustomStorageApp: React.FC = () => {
 };
 
 export default CustomStorageApp;
+```
+
+As this example uses AWS S3, you will also need to enable cors in the bucket,
+as described in the [AWS documentation - Configuring cross-origin resource sharing (CORS)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/enabling-cors-examples.html?icmpid=docs_amazons3_console).
+
+```json
+[
+    {
+        "AllowedHeaders": [
+            "*"
+        ],
+        "AllowedMethods": [
+            "GET",
+            "PUT",
+            "POST",
+            "DELETE"
+        ],
+        "AllowedOrigins": [
+            "*"
+        ],
+        "ExposeHeaders": [
+            "x-amz-server-side-encryption",
+            "x-amz-request-id",
+            "x-amz-id-2"
+        ],
+        "MaxAgeSeconds": 3000
+    }
+]
 ```
 
 This documentation provides a clear guide for defining custom storage solutions in FireCMS. Follow the template to integrate other storage services as per your requirements.


### PR DESCRIPTION
Added an example of a working S3 integration for storage.

As Amplify v2 now supports Storage, that might be a better solution, but this is indeed simpler and straightforwards. I think it works as an example of how you can implement any storage service.

Maybe we should also includo Minio, which is an open source storage service.