### PR TITLE
Bugfix for inherited sort in ReferenceDialog from root collection

### DIFF
--- a/packages/firecms_core/src/components/common/useDataSourceTableController.tsx
+++ b/packages/firecms_core/src/components/common/useDataSourceTableController.tsx
@@ -134,7 +134,7 @@ export function useDataSourceTableController<M extends Record<string, any> = any
     } = parseFilterAndSort(window.location.search);
 
     const [filterValues, setFilterValues] = React.useState<FilterValues<Extract<keyof M, string>> | undefined>(forceFilter ?? (updateUrl ? initialFilterUrl : undefined) ?? initialFilter ?? undefined);
-    const [sortBy, setSortBy] = React.useState<[Extract<keyof M, string>, "asc" | "desc"] | undefined>(initialSortUrl ?? initialSortInternal);
+    const [sortBy, setSortBy] = React.useState<[Extract<keyof M, string>, "asc" | "desc"] | undefined>((updateUrl ? initialSortUrl : undefined) ?? initialSortInternal);
 
     useUpdateUrl(filterValues, sortBy, searchString, updateUrl);
 


### PR DESCRIPTION
This pull request includes a minor adjustment to the `useDataSourceTableController` function in the `packages/firecms_core/src/components/common/useDataSourceTableController.tsx` file. The change updates the initialization logic for the `sortBy` state to consider the `updateUrl` flag when determining whether to use `initialSortUrl`.

fix: when opening a reference dialog, the DataSourceTableController w…as using the url parameters to apply sort values. So when having a filter in a main collection, the sorting was applied also to the dialog one, also on fields the referenced collection may not have. Implemented a small fix, similar to what is being applied to the filter feature when used in a dialog, using the updateUrl prop. This is a fix for https://github.com/firecmsco/firecms/issues/702.