### PR TITLE
Removed references to non-existant collections from example demo

### DIFF
--- a/examples/example/src/collections/demo.tsx
+++ b/examples/example/src/collections/demo.tsx
@@ -194,23 +194,6 @@ export const demoCollection = buildCollection({
             expanded: true
         },
 
-        // reference to another collection
-        client: {
-            dataType: "reference",
-            path: "users",
-            name: "Related client"
-        },
-
-        // multiple references to another collection
-        related_products: {
-            dataType: "array",
-            name: "Related products",
-            of: {
-                dataType: "reference",
-                path: "products"
-            }
-        },
-
         // block of content with dynamic properties
         content: {
             name: "Content",


### PR DESCRIPTION
## 📝 Description
The referenced collections in the example demo collection do not exist, so I removed them.

## 🔗 Related Issues
- Fixes #740 

## 🛠️ Type of Change
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🧹 Refactoring / Style update (no functional changes)

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
- [ ] **Unit Tests:** (e.g., `npm test`, `pytest`)
- [X] **Manual Testing:** Describe the steps taken to test manually.
- [ ] **Environment:** OS: MacOS, Browser: Vivaldi, FireCMS version: 3.0.0

## 📸 Screenshots / Demos (if applicable)
<img width="1396" height="1656" alt="image" src="https://github.com/user-attachments/assets/3e75b10a-286d-45d5-a238-7c703b45952c" />