### PR TITLE
Table pagination - Fixed bug when page size is small

### DIFF
--- a/packages/firecms_core/src/components/VirtualTable/VirtualTable.tsx
+++ b/packages/firecms_core/src/components/VirtualTable/VirtualTable.tsx
@@ -135,7 +135,7 @@ export const VirtualTable = React.memo<VirtualTableProps<any>>(
         const [columns, setColumns] = useState(columnsProp);
 
         const tableRef = useRef<HTMLDivElement>(null);
-        const endReachCallbackThreshold = useRef<number>(0);
+        const lastEndReachedDataLength = useRef<number | undefined>(undefined);
 
         const debouncedScroll = useDebounceCallback(onScrollProp, 200);
 
@@ -242,7 +242,7 @@ export const VirtualTable = React.memo<VirtualTableProps<any>>(
         }, [filterInput]);
 
         const scrollToTop = useCallback(() => {
-            endReachCallbackThreshold.current = 0;
+            lastEndReachedDataLength.current = undefined;
             if (tableRef.current) {
                 tableRef.current.scrollTo(tableRef.current?.scrollLeft, 0);
             }
@@ -278,12 +278,23 @@ export const VirtualTable = React.memo<VirtualTableProps<any>>(
 
         const maxScroll = Math.max((data?.length ?? 0) * rowHeight - bounds.height, 0);
 
-        const onEndReachedInternal = useCallback((scrollOffset: number) => {
-            if (onEndReached && (data?.length ?? 0) > 0 && scrollOffset > endReachCallbackThreshold.current + endOffset) {
-                endReachCallbackThreshold.current = scrollOffset;
+        const onEndReachedInternal = useCallback(() => {
+            const dataLength = data?.length ?? 0;
+
+            if (onEndReached && dataLength > 0 && lastEndReachedDataLength.current !== dataLength) {
+                lastEndReachedDataLength.current = dataLength;
                 onEndReached();
             }
         }, [data?.length, onEndReached]);
+
+        useEffect(() => {
+            if (!onEndReached || loading || !data?.length || !bounds.height || !tableRef.current) {
+                return;
+            }
+            if (tableRef.current.scrollHeight <= tableRef.current.clientHeight) {
+                onEndReachedInternal();
+            }
+        }, [bounds.height, data?.length, loading, onEndReached, onEndReachedInternal]);
 
         const onScroll = useCallback(({
             scrollDirection,
@@ -302,12 +313,12 @@ export const VirtualTable = React.memo<VirtualTableProps<any>>(
                 })
             }
             if (!scrollUpdateWasRequested && (scrollOffset >= maxScroll - endOffset))
-                onEndReachedInternal(scrollOffset);
-        }, [maxScroll, onEndReachedInternal]);
+                onEndReachedInternal();
+        }, [endOffset, maxScroll, onEndReachedInternal]);
 
         const onFilterUpdateInternal = useCallback((column: VirtualTableColumn, filterForProperty?: [VirtualTableWhereFilterOp, any]) => {
 
-            endReachCallbackThreshold.current = 0;
+            lastEndReachedDataLength.current = undefined;
             const filter = filterRef.current;
             let newFilterValue: VirtualTableFilterValues<any> = filter ? { ...filter } : {};
 


### PR DESCRIPTION
Summary

Fixes collection table pagination getting stuck when small page sizes are used, such as `pagination: 10`.

## Problem

`VirtualTable` used `endOffset` both to detect when the user was near the bottom and to throttle repeated `onEndReached` callbacks. With the default `endOffset` of `600px`, pagination could fail when the table had no scroll area, or when the available scroll distance was smaller than `600px`.

## Changes

- Request more rows when the current table content does not fill the viewport.
- Trigger `onEndReached` once per loaded `data.length` instead of requiring the scroll offset to advance by `endOffset` pixels.
- Keep the existing `endOffset` behavior for deciding when the user is near the bottom.

## Testing

- Tested a collection with `pagination: 10` and more than 10 documents.
- Verified large viewports continue loading when the first page does not fill the table.
- Verified smaller viewports load more when scrolling to the bottom, even when the scrollable distance is less than `600px`.
- Ran ESLint on the edited files.

## Screenshots

Page size 10 on big screen
<img width="1436" height="1154" alt="page_10_big_fix" src="https://github.com/user-attachments/assets/4977898d-08d5-4bf1-9c75-8088a37ec4dc" />

Page size 2 on small screen
<img width="1436" height="606" alt="page_2_small" src="https://github.com/user-attachments/assets/4669b001-4f8b-4861-b120-f435b22af096" />

Closes [#912](https://github.com/firecmsco/firecms/issues/912)
