### PR TITLE
Fix collection editor state reuse for nested properties

### DIFF
--- a/packages/collection_editor/src/ui/collection_editor/CollectionPropertiesEditorForm.tsx
+++ b/packages/collection_editor/src/ui/collection_editor/CollectionPropertiesEditorForm.tsx
@@ -503,7 +503,7 @@ export function CollectionPropertiesEditorForm({
                             !isPropertyBuilder(selectedProperty) &&
                             <PropertyForm
                                 inArray={false}
-                                key={`edit_view_${selectedPropertyIndex}_${generationCounter}`}
+                                key={`edit_view_${selectedPropertyFullId}_${generationCounter}`}
                                 existingProperty={!isNewCollection}
                                 autoUpdateId={false}
                                 allowDataInference={!isNewCollection}
@@ -547,7 +547,7 @@ export function CollectionPropertiesEditorForm({
             {asDialog && <PropertyFormDialog
                 inArray={false}
                 open={selectedPropertyIndex !== undefined}
-                key={`edit_view_${selectedPropertyIndex}_${generationCounter}`}
+                key={`edit_view_${selectedPropertyFullId}_${generationCounter}`}
                 autoUpdateId={!selectedProperty}
                 allowDataInference={!isNewCollection}
                 existingProperty={true}


### PR DESCRIPTION
## What changed

Use `selectedPropertyFullId` instead of `selectedPropertyIndex` in the React keys for both the inline `PropertyForm` and `PropertyFormDialog`.

## Why

`selectedPropertyIndex` is calculated against the top-level `usedPropertiesOrder`. Nested property keys are not present in that array, so different nested properties can resolve to the same index (typically `-1`). React then reuses the same form component instance when the selection changes, allowing form-local state from the previously selected property to appear in the next one.

`selectedPropertyFullId` includes the property namespace and key, so it uniquely identifies nested properties and causes the editor form to remount when the selected property changes.

## Reproduction

1. Open the collection editor for a collection containing nested map properties.
2. Select one nested property and interact with its property form.
3. Select a different nested property.
4. Before this change, the second property can reuse form-local state from the first because both selections share the same React key.
