### PR TITLE
fix(core): clear notAllowedError so a valid user can log in after a rejected one

### DIFF
--- a/packages/firecms_core/src/hooks/useValidateAuthenticator.tsx
+++ b/packages/firecms_core/src/hooks/useValidateAuthenticator.tsx
@@ -74,6 +74,10 @@ export function useValidateAuthenticator<USER extends User = any>
 
         if (authenticator instanceof Function && delegateUser && !equal(checkedUserRef.current?.uid, delegateUser.uid)) {
             setAuthLoading(true);
+            // Reset the error of any previous authentication attempt. Otherwise, a
+            // rejected user would keep `canAccessMainView` to false for every user
+            // logging in afterwards, locking them out of the CMS until a page reload.
+            setNotAllowedError(false);
             try {
                 const allowed = await authenticator({
                     user: delegateUser,

--- a/packages/firecms_core/test/useValidateAuthenticator.test.tsx
+++ b/packages/firecms_core/test/useValidateAuthenticator.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ */
+import { describe, expect, it } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react";
+import { useCallback, useState } from "react";
+
+import { useValidateAuthenticator } from "../src/hooks/useValidateAuthenticator";
+
+const userA = { uid: "user-a" } as any;
+const userB = { uid: "user-b" } as any;
+
+/**
+ * Minimal auth controller, modelled after `useFirebaseAuthController`:
+ * it returns a brand new object on every render, and signing out clears the
+ * logged user through React state, which triggers a re-render.
+ */
+function useTestAuthController() {
+    const [user, setUser] = useState<any>(null);
+    const signOut = useCallback(() => setUser(null), []);
+    return {
+        user,
+        setUser,
+        signOut,
+        initialLoading: false,
+        loginSkipped: false,
+        authLoading: false
+    } as any;
+}
+
+/**
+ * Note: the authenticators used here must be plain functions declared in this
+ * file, since the hook checks `authenticator instanceof Function` and jest mock
+ * functions belong to a different realm than the jsdom test globals.
+ */
+function renderValidateAuthenticator(authenticator: any) {
+    return renderHook(() => {
+        const authController = useTestAuthController();
+        const validation = useValidateAuthenticator({
+            authController,
+            authenticator,
+            dataSourceDelegate: {} as any,
+            storageSource: {} as any
+        });
+        return {
+            authController,
+            ...validation
+        };
+    });
+}
+
+/**
+ * Flush the pending promises of the authenticator, plus the re-renders they
+ * cascade into, like the sign out performed on a rejected user.
+ */
+async function flush() {
+    for (let i = 0; i < 5; i++) {
+        await act(async () => {
+            await Promise.resolve();
+        });
+    }
+}
+
+describe("useValidateAuthenticator", () => {
+
+    it("allows a user accepted by the authenticator", async () => {
+        const { result } = renderValidateAuthenticator(async () => true);
+
+        await act(async () => {
+            result.current.authController.setUser(userA);
+        });
+        await flush();
+
+        expect(result.current.notAllowedError).toBe(false);
+        expect(result.current.canAccessMainView).toBe(true);
+    });
+
+    it("rejects a user denied by the authenticator, and keeps the error while on the login screen", async () => {
+        const { result } = renderValidateAuthenticator(async () => false);
+
+        await act(async () => {
+            result.current.authController.setUser(userA);
+        });
+        await flush();
+
+        // the rejected user is signed out, and the error is exposed so the login
+        // view can display it
+        expect(result.current.authController.user).toBeNull();
+        expect(result.current.notAllowedError).toBeTruthy();
+        expect(result.current.canAccessMainView).toBe(false);
+
+        // further re-renders must not wipe the error, otherwise the login view
+        // would never get the chance to show it
+        await flush();
+        expect(result.current.notAllowedError).toBeTruthy();
+    });
+
+    it("clears the error when an allowed user logs in after a rejected one", async () => {
+        const { result } = renderValidateAuthenticator(async ({ user }: any) => user.uid === userB.uid);
+
+        // user A is not allowed
+        await act(async () => {
+            result.current.authController.setUser(userA);
+        });
+        await flush();
+
+        expect(result.current.notAllowedError).toBeTruthy();
+        expect(result.current.canAccessMainView).toBe(false);
+
+        // user B is allowed, so the stale error must not lock them out
+        await act(async () => {
+            result.current.authController.setUser(userB);
+        });
+        await flush();
+
+        expect(result.current.notAllowedError).toBe(false);
+        expect(result.current.canAccessMainView).toBe(true);
+        expect(result.current.authLoading).toBe(false);
+        expect(result.current.authVerified).toBe(true);
+    });
+
+    it("clears an error thrown by the authenticator when an allowed user logs in", async () => {
+        const error = new Error("Not allowed");
+        const { result } = renderValidateAuthenticator(async ({ user }: any) => {
+            if (user.uid === userA.uid)
+                throw error;
+            return true;
+        });
+
+        await act(async () => {
+            result.current.authController.setUser(userA);
+        });
+        await flush();
+
+        expect(result.current.notAllowedError).toBe(error);
+        expect(result.current.canAccessMainView).toBe(false);
+
+        await act(async () => {
+            result.current.authController.setUser(userB);
+        });
+        await flush();
+
+        expect(result.current.notAllowedError).toBe(false);
+        expect(result.current.canAccessMainView).toBe(true);
+    });
+
+    it("does not keep validating the same user once it has been checked", async () => {
+        let calls = 0;
+        const { result, rerender } = renderValidateAuthenticator(async () => {
+            calls++;
+            return true;
+        });
+
+        await act(async () => {
+            result.current.authController.setUser(userA);
+        });
+        await flush();
+
+        const callsAfterLogin = calls;
+
+        rerender();
+        await flush();
+
+        expect(calls).toBe(callsAfterLogin);
+        expect(result.current.canAccessMainView).toBe(true);
+    });
+
+});


### PR DESCRIPTION
Fixes #708

## The bug
Once `notAllowedError` was set in `useValidateAuthenticator`, it was never cleared. It is only ever assigned `true` or a caught error, and `canAccessMainView` includes `!notAllowedError`. So after one rejected login, a **legitimate** user logging in afterwards stayed stuck on the login screen until a full page reload.

## The fix
One `setNotAllowedError(false)`, placed inside the `checkedUserRef`-guarded block before the authenticator runs.

**Why not at the top of `checkAuthentication`** (the obvious spot): `useFirebaseAuthController` returns a fresh object literal every render (no `useMemo`), so `authController` is an unstable `useCallback` dep and the effect re-runs on *every* render. An unconditional reset there fires right after `signOut()` and wipes the error before the login view can display it — regressing the one behaviour the reporter said already worked. This was tested, not assumed: with the reset at the top, 3 of the 5 new tests fail.

Placing it in the guarded block ties the error's lifetime to a validation *attempt*, runs at most once per uid change, and batches with the existing `setAuthLoading(true)`.

## Tests
New suite, 5 tests. Reverting only the source change makes exactly the two "clears the error" tests fail; the other 3 pass either way as guardrails.

`@firecms/core`: 242/245 passing (was 237/240) — 3 pre-existing failures unchanged.

## Follow-ups found, deliberately not included
- **`authenticator instanceof Function` is realm-sensitive** — a `jest.fn()` fails that check under jsdom, so a mocked authenticator is silently skipped. `typeof authenticator === "function"` would be robust.
- **The authenticator can run twice per login** — `checkedUserRef.current` is assigned only *after* the `await`, so a re-render during the async call re-enters the block. Pre-existing, not worsened, but it matters if an authenticator performs writes.
- **Skip-login path still stuck** — a rejected user who then clicks "skip login" keeps the error set. Clearing it there would let a denied user in via the skip path; that's an authorization decision for maintainers.

## Not verified
Unit-level only — not exercised in a browser against a real Firebase project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
