### PR TITLE
fix(firebase): return content type and plain file name from getFile

### DIFF
--- a/packages/firebase_firecms/src/hooks/useFirebaseStorageSource.ts
+++ b/packages/firebase_firecms/src/hooks/useFirebaseStorageSource.ts
@@ -136,7 +136,12 @@ export function useFirebaseStorageSource({
                 const url = await getDownloadURL(fileRef);
                 const response = await fetch(url);
                 const blob = await response.blob();
-                return new File([blob], path);
+                // `blob.type` is the `Content-Type` served by Firebase Storage, i.e. the
+                // `contentType` metadata of the stored object. It must be passed explicitly,
+                // otherwise the resulting `File` would have an empty `type`.
+                // `fileRef.name` is the last component of the path: a `File` name should be a
+                // file name, not a full storage path.
+                return new File([blob], fileRef.name, { type: blob.type });
             } catch (e: any) {
                 if (e?.code === "storage/object-not-found") return null;
                 throw e;


### PR DESCRIPTION
Fixes #556

## The bug
`getFile` built its result with `new File([blob], path)`, omitting the constructor's third argument. Without it `File.type` is `""`, even though the content type was already sitting on the fetched `blob`.

## The fix
```diff
-return new File([blob], path);
+return new File([blob], fileRef.name, { type: blob.type });
```

Two changes, both deliberate:

**`{ type: blob.type }`** — Firebase serves the object's stored `contentType` as the response `Content-Type`, so `blob.type` *is* the stored metadata, arriving free with a response we already await. An extra `getMetadata()` round-trip would return the identical string.

**`fileRef.name` instead of `path`** — the full storage path was used as the `File` name, giving names like `images/events/abc.png`. Not cosmetic: the default filename builder composes `randomString() + "_" + file.name`, so re-uploading a fetched file created spurious nested pseudo-folders in Storage. `fileRef.name` is documented by `@firebase/storage` as the last path component, which avoids hand-rolling trailing-slash edge cases.

Blast radius checked first: only three `getFile` references exist in source (the interface, this implementation, and a throwing mock) and none reads `File.name`.

## Not verified
`packages/firebase_firecms` has no test runner wired up, so no tests were added for a one-line fix. `tsc --noEmit` is clean for this file. Not exercised against live Firebase Storage — the `blob.type` behaviour rests on documented behaviour, not an observed round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
