### PR TITLE
fix(core): preview externally hosted URLs in storage properties

### DIFF
--- a/packages/firebase_firecms/src/hooks/useFirebaseStorageSource.ts
+++ b/packages/firebase_firecms/src/hooks/useFirebaseStorageSource.ts
@@ -10,6 +10,8 @@ import {
 } from "@firebase/storage";
 import { DownloadConfig, DownloadMetadata, StorageListResult, StorageSource, UploadFileProps } from "@firecms/core";
 
+const ABSOLUTE_HTTP_URL_REGEX = /^https?:\/\//i;
+
 /**
  * @group Firebase
  */
@@ -179,6 +181,18 @@ export function useFirebaseStorageSource({
                     url: null,
                     fileNotFound: true
                 };
+                // `ref` throws `storage/invalid-url` for absolute URLs that it cannot
+                // parse as a Firebase Storage location: files hosted outside of Firebase,
+                // or download URLs of a bucket/host this app is not pointing at (which
+                // happens routinely when running against the storage emulator).
+                // Those values are already usable URLs, so they are returned as they are.
+                // Firebase download URLs are still resolved through `ref` above, so their
+                // real content type keeps being reported by `getMetadata`.
+                if (e?.code === "storage/invalid-url" && ABSOLUTE_HTTP_URL_REGEX.test(storagePathOrUrl)) {
+                    const result: DownloadConfig = { url: storagePathOrUrl };
+                    urlsCache[storagePathOrUrl] = result;
+                    return result;
+                }
                 throw e;
             }
         },

--- a/packages/firecms_core/src/preview/components/StorageThumbnail.tsx
+++ b/packages/firecms_core/src/preview/components/StorageThumbnail.tsx
@@ -6,6 +6,7 @@ import { useStorageSource } from "../../hooks";
 import { DownloadConfig, FileType } from "../../types";
 import { PreviewSize } from "../PropertyPreviewProps";
 import { ErrorView } from "../../components";
+import { getPreviewTypeFromUrl, isAbsoluteHttpUrl } from "../../util/urls";
 
 type StorageThumbnailProps = {
     storagePathOrDownloadUrl: string;
@@ -41,10 +42,20 @@ export function StorageThumbnailInternal({
     const [error, setError] = React.useState<Error | undefined>(undefined);
     const storage = useStorageSource();
 
+    /**
+     * The saved value may already be a resolved download URL instead of a
+     * storage path: either because the property is configured with
+     * `storeUrl: true`, or because the value was written directly in the
+     * datasource pointing to an externally hosted file. Such values can be
+     * previewed as they are, and must not be handed over to the storage source,
+     * which can only resolve paths of its own bucket.
+     */
+    const valueIsUrl = storeUrl || isAbsoluteHttpUrl(storagePathOrDownloadUrl);
+
     const [downloadConfig, setDownloadConfig] = React.useState<DownloadConfig>(URL_CACHE[storagePathOrDownloadUrl]);
 
     useEffect(() => {
-        if (!storagePathOrDownloadUrl)
+        if (!storagePathOrDownloadUrl || valueIsUrl)
             return;
         let unmounted = false;
         storage.getDownloadURL(storagePathOrDownloadUrl)
@@ -57,9 +68,20 @@ export function StorageThumbnailInternal({
         return () => {
             unmounted = true;
         };
-    }, [storagePathOrDownloadUrl]);
+    }, [storagePathOrDownloadUrl, valueIsUrl]);
 
     if (!storagePathOrDownloadUrl) return null;
+
+    if (valueIsUrl) {
+        // There is no storage metadata for a value that is already a URL, so the
+        // preview type is inferred from its file extension when possible.
+        return <UrlComponentPreview previewType={getPreviewTypeFromUrl(storagePathOrDownloadUrl) ?? "file"}
+            url={storagePathOrDownloadUrl}
+            interactive={interactive}
+            size={size}
+            fill={fill}
+            hint={storagePathOrDownloadUrl} />;
+    }
 
     const filetype = downloadConfig?.metadata ? getFiletype(downloadConfig?.metadata.contentType) : undefined;
     const previewType = filetype?.startsWith("image")

--- a/packages/firecms_core/src/util/__tests__/urls.test.ts
+++ b/packages/firecms_core/src/util/__tests__/urls.test.ts
@@ -1,0 +1,131 @@
+import { getFileExtensionFromUrl, getPreviewTypeFromUrl, isAbsoluteHttpUrl } from "../urls";
+
+describe("url utilities", () => {
+
+    describe("isAbsoluteHttpUrl", () => {
+
+        it("should detect absolute http and https URLs", () => {
+            expect(isAbsoluteHttpUrl("https://abc.com/abc.png")).toBe(true);
+            expect(isAbsoluteHttpUrl("http://abc.com/abc.png")).toBe(true);
+            expect(isAbsoluteHttpUrl("HTTPS://ABC.COM/ABC.PNG")).toBe(true);
+        });
+
+        it("should detect Firebase Storage download URLs as absolute URLs", () => {
+            expect(isAbsoluteHttpUrl("https://firebasestorage.googleapis.com/v0/b/demo.appspot.com/o/images%2Fcat.png?alt=media&token=abc")).toBe(true);
+            expect(isAbsoluteHttpUrl("https://storage.googleapis.com/demo.appspot.com/images/cat.png")).toBe(true);
+        });
+
+        it("should not consider storage paths absolute URLs", () => {
+            expect(isAbsoluteHttpUrl("images/cat.png")).toBe(false);
+            expect(isAbsoluteHttpUrl("/images/cat.png")).toBe(false);
+            expect(isAbsoluteHttpUrl("cat.png")).toBe(false);
+        });
+
+        it("should not consider other protocols absolute http URLs", () => {
+            expect(isAbsoluteHttpUrl("gs://demo.appspot.com/images/cat.png")).toBe(false);
+            expect(isAbsoluteHttpUrl("data:image/png;base64,AAAA")).toBe(false);
+            expect(isAbsoluteHttpUrl("//abc.com/abc.png")).toBe(false);
+        });
+
+        it("should handle empty values", () => {
+            expect(isAbsoluteHttpUrl("")).toBe(false);
+            expect(isAbsoluteHttpUrl(undefined)).toBe(false);
+            expect(isAbsoluteHttpUrl(null)).toBe(false);
+        });
+
+        it("should not match http appearing later in the value", () => {
+            expect(isAbsoluteHttpUrl("images/https://abc.com/abc.png")).toBe(false);
+        });
+
+    });
+
+    describe("getFileExtensionFromUrl", () => {
+
+        it("should extract the extension of a plain URL", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/abc.png")).toBe("png");
+        });
+
+        it("should lowercase the extension", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/ABC.PNG")).toBe("png");
+        });
+
+        it("should ignore query strings and hash fragments", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/abc.png?width=200")).toBe("png");
+            expect(getFileExtensionFromUrl("https://abc.com/abc.png#anchor")).toBe("png");
+            expect(getFileExtensionFromUrl("https://firebasestorage.googleapis.com/v0/b/demo.appspot.com/o/images%2Fcat.jpeg?alt=media&token=abc")).toBe("jpeg");
+        });
+
+        it("should work with storage paths", () => {
+            expect(getFileExtensionFromUrl("images/cat.webp")).toBe("webp");
+        });
+
+        it("should use the last dot of the file name", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/archive.tar.gz")).toBe("gz");
+        });
+
+        it("should return undefined when there is no extension", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/abc")).toBeUndefined();
+            expect(getFileExtensionFromUrl("https://abc.com/")).toBeUndefined();
+            expect(getFileExtensionFromUrl("images/cat")).toBeUndefined();
+        });
+
+        it("should not take dots of the host or the path as extensions", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/images/cat")).toBeUndefined();
+            expect(getFileExtensionFromUrl("https://abc.com/abc.png/download")).toBeUndefined();
+        });
+
+        it("should return undefined for dotfiles and trailing dots", () => {
+            expect(getFileExtensionFromUrl("https://abc.com/.gitignore")).toBeUndefined();
+            expect(getFileExtensionFromUrl("https://abc.com/abc.")).toBeUndefined();
+        });
+
+        it("should handle empty values", () => {
+            expect(getFileExtensionFromUrl("")).toBeUndefined();
+            expect(getFileExtensionFromUrl(undefined)).toBeUndefined();
+            expect(getFileExtensionFromUrl(null)).toBeUndefined();
+        });
+
+    });
+
+    describe("getPreviewTypeFromUrl", () => {
+
+        it("should infer image previews", () => {
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.png")).toBe("image");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.jpg")).toBe("image");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.jpeg")).toBe("image");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.gif")).toBe("image");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.webp")).toBe("image");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.svg")).toBe("image");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.avif")).toBe("image");
+        });
+
+        it("should infer video previews", () => {
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.mp4")).toBe("video");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.webm")).toBe("video");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.mov")).toBe("video");
+        });
+
+        it("should infer audio previews", () => {
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.mp3")).toBe("audio");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.wav")).toBe("audio");
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.m4a")).toBe("audio");
+        });
+
+        it("should infer the type of Firebase Storage download URLs", () => {
+            expect(getPreviewTypeFromUrl("https://firebasestorage.googleapis.com/v0/b/demo.appspot.com/o/images%2Fcat.png?alt=media&token=abc")).toBe("image");
+        });
+
+        it("should be case insensitive", () => {
+            expect(getPreviewTypeFromUrl("https://abc.com/ABC.PNG")).toBe("image");
+        });
+
+        it("should return undefined for unknown or missing extensions", () => {
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.pdf")).toBeUndefined();
+            expect(getPreviewTypeFromUrl("https://abc.com/abc.zip")).toBeUndefined();
+            expect(getPreviewTypeFromUrl("https://abc.com/abc")).toBeUndefined();
+            expect(getPreviewTypeFromUrl(undefined)).toBeUndefined();
+        });
+
+    });
+
+});

--- a/packages/firecms_core/src/util/index.ts
+++ b/packages/firecms_core/src/util/index.ts
@@ -6,6 +6,7 @@ export * from "./enums";
 export * from "./objects";
 export * from "./paths";
 export * from "./regexp";
+export * from "./urls";
 export * from "./navigation_utils";
 export * from "./entity_actions";
 export * from "./useDebouncedCallback";

--- a/packages/firecms_core/src/util/urls.ts
+++ b/packages/firecms_core/src/util/urls.ts
@@ -1,0 +1,52 @@
+import type { PreviewType } from "../types";
+
+const ABSOLUTE_HTTP_URL_REGEX = /^https?:\/\//i;
+
+const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "gif", "webp", "avif", "bmp", "svg", "ico", "tif", "tiff", "heic", "heif"];
+const VIDEO_EXTENSIONS = ["mp4", "webm", "ogv", "mov", "m4v", "avi", "mkv", "mpeg", "mpg", "3gp"];
+const AUDIO_EXTENSIONS = ["mp3", "wav", "ogg", "oga", "m4a", "aac", "flac", "weba", "opus", "mid", "midi"];
+
+/**
+ * Is the given value an absolute `http(s)` URL, as opposed to a relative
+ * storage path such as `images/my_image.png`?
+ *
+ * Values saved in the datasource for storage properties can be either, e.g.
+ * when the property is configured with `storeUrl: true`, or when the value was
+ * written directly pointing to an externally hosted file.
+ */
+export function isAbsoluteHttpUrl(value?: string | null): boolean {
+    if (!value) return false;
+    return ABSOLUTE_HTTP_URL_REGEX.test(value);
+}
+
+/**
+ * Extract the lowercase file extension of a URL or path, ignoring any query
+ * string or hash fragment. Returns `undefined` when there is no extension.
+ */
+export function getFileExtensionFromUrl(urlOrPath?: string | null): string | undefined {
+    if (!urlOrPath) return undefined;
+    // Query strings and hash fragments are not part of the file name, and they
+    // are common in download URLs, e.g. `?alt=media&token=...`
+    const withoutQuery = urlOrPath.split(/[?#]/)[0];
+    const lastSegment = withoutQuery.split("/").pop();
+    if (!lastSegment) return undefined;
+    const lastDot = lastSegment.lastIndexOf(".");
+    // No dot, a leading dot (a dotfile), or a trailing dot means no extension
+    if (lastDot <= 0 || lastDot === lastSegment.length - 1) return undefined;
+    return lastSegment.substring(lastDot + 1).toLowerCase();
+}
+
+/**
+ * Best effort guess of the preview type of a URL or path, based on its file
+ * extension. Used when no storage metadata (and therefore no content type) is
+ * available, e.g. for externally hosted files.
+ * Returns `undefined` when the extension is missing or not recognised.
+ */
+export function getPreviewTypeFromUrl(urlOrPath?: string | null): PreviewType | undefined {
+    const extension = getFileExtensionFromUrl(urlOrPath);
+    if (!extension) return undefined;
+    if (IMAGE_EXTENSIONS.includes(extension)) return "image";
+    if (VIDEO_EXTENSIONS.includes(extension)) return "video";
+    if (AUDIO_EXTENSIONS.includes(extension)) return "audio";
+    return undefined;
+}


### PR DESCRIPTION
Fixes #550

A string property with a `storage` config crashed the preview with `FirebaseError: Firebase Storage: Invalid URL` whenever the stored value was an externally hosted URL rather than a path in the configured bucket. Two separate defects combined.

## Defect 1 — `StorageThumbnail` ignored its own `storeUrl` prop
The prop was declared and compared in the `areEqual` memo comparator, but never read in the component body, so every value was unconditionally sent to `storage.getDownloadURL()` even when it already was a resolved download URL.

## Defect 2 — no pass-through for external URLs
`getDownloadURL()` special-cased `gs://` but handed any other absolute URL straight to `ref()`, which throws `storage/invalid-url` for anything it cannot parse as a Storage location.

## Why this does not use a host allowlist
The obvious fix is to match `firebasestorage.googleapis.com` / `storage.googleapis.com`. **That would be wrong.** `Location.makeFromUrl(url, host)` builds its regexes from the **runtime** `storage.host`, so when the SDK points at the storage emulator, production Firebase download URLs are `storage/invalid-url` too:

```
--- production host ---          ACCEPTED  https://firebasestorage.googleapis.com/v0/b/demo-proj...
--- emulator 127.0.0.1:9199 ---  THREW storage/invalid-url   (same URL)
```

That is exactly the reporter's "emulator against a live project's storage" scenario, so an allowlist would still have crashed. This defers to Firebase's own parser and catches `storage/invalid-url`, gated on `^https?://` so a malformed *path* still throws. It needs no maintenance as Firebase adds hosts (e.g. `*.firebasestorage.app`) and cannot regress any URL `ref()` accepts today.

The two layers compose rather than duplicate: the core fix means the storage source is never consulted for an absolute URL; the Firebase fix covers every other `getDownloadURL` caller.

## Tests
New pure helpers in `util/urls.ts` with 21 unit tests (external vs Firebase vs `gs://` vs paths vs `data:`; extension extraction through query strings and hashes; preview-type inference).

`@firecms/core`: 258/261 passing (was 237/240) — 3 pre-existing failures unchanged.

## Behaviour change worth reviewing
`storeUrl: true` thumbnails no longer make a `getDownloadURL` + `getMetadata` round-trip — a real perf win in list views — but preview type now comes from the file extension rather than `contentType`. FireCMS's own upload path preserves extensions, and `.pdf`/`.zip` map to `"file"` exactly as `application/*` did, so no visible change is expected; an extension-less stored filename would degrade from image preview to file link.

## Separate pre-existing bug found, left alone
The `error` state in `StorageThumbnail` is also dead — `setError` is passed to `.catch()` but `error` is never read in the render, so a failed resolution shows the skeleton forever.

## Not verified
The end-to-end preview needs a browser and a real Firebase project. The render branch is verified by typecheck and reading, plus a functional probe of the patched `getDownloadURL` control flow against the real SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
