### PR TITLE
fix(core): restore the collection search term from the URL

### DIFF
--- a/packages/firecms_core/src/components/EntityCollectionTable/EntityCollectionTable.tsx
+++ b/packages/firecms_core/src/components/EntityCollectionTable/EntityCollectionTable.tsx
@@ -354,6 +354,7 @@ export const EntityCollectionTable = function EntityCollectionTable<M extends Re
                 onTextSearch={textSearchEnabled ? onTextSearch : undefined}
                 textSearchLoading={textSearchLoading}
                 onTextSearchClick={textSearchEnabled ? onTextSearchClick : undefined}
+                initialSearchString={tableController.searchString}
                 title={title}
                 actionsStart={actionsStart}
                 actions={actions}

--- a/packages/firecms_core/src/components/EntityCollectionTable/internal/CollectionTableToolbar.tsx
+++ b/packages/firecms_core/src/components/EntityCollectionTable/internal/CollectionTableToolbar.tsx
@@ -20,6 +20,11 @@ interface CollectionTableToolbarProps {
     onTextSearchClick?: () => void;
     onTextSearch?: (searchString?: string) => void;
     textSearchLoading?: boolean;
+    /**
+     * Search term the search bar should start with, typically the one restored from the
+     * URL query params by the table controller.
+     */
+    initialSearchString?: string;
 }
 
 export function CollectionTableToolbar({
@@ -29,6 +34,7 @@ export function CollectionTableToolbar({
     onTextSearch,
     onTextSearchClick,
     textSearchLoading,
+    initialSearchString,
     title,
     viewModeToggle
 }: CollectionTableToolbarProps) {
@@ -79,6 +85,7 @@ export function CollectionTableToolbar({
                         disabled={Boolean(onTextSearchClick)}
                         onClick={onTextSearchClick}
                         onTextSearch={onTextSearchClick ? undefined : onTextSearch}
+                        initialValue={initialSearchString}
                         placeholder={t("search")}
                         expandable={true} />}
 

--- a/packages/firecms_core/src/components/EntityCollectionView/EntityCollectionView.tsx
+++ b/packages/firecms_core/src/components/EntityCollectionView/EntityCollectionView.tsx
@@ -831,7 +831,11 @@ export const EntityCollectionView = React.memo(
         } = useTableSearchHelper({
             collection,
             fullPath: resolvedFullPath,
-            parentCollectionIds
+            parentCollectionIds,
+            // When the search term comes from the URL instead of the search bar, text search
+            // has never been initialised for this collection. Initialise it so the search bar
+            // is usable (editable and clearable) right away.
+            initialSearchString: tableController.searchString
         });
 
         // Popover open state managed at parent level to prevent closing when view changes
@@ -881,6 +885,7 @@ export const EntityCollectionView = React.memo(
                     loading={tableController.dataLoading}
                     onTextSearch={textSearchEnabled && textSearchInitialised ? tableController.setSearchString : undefined}
                     onTextSearchClick={textSearchEnabled && !textSearchInitialised ? onTextSearchClick : undefined}
+                    initialSearchString={tableController.searchString}
                     textSearchLoading={textSearchLoading}
                     viewModeToggle={viewModeToggleElement}
                     actionsStart={<EntityCollectionViewStartActions

--- a/packages/firecms_core/src/components/common/table_url_params.ts
+++ b/packages/firecms_core/src/components/common/table_url_params.ts
@@ -1,0 +1,172 @@
+import { EntityReference, FilterValues, WhereFilterOp } from "../../types";
+import { decodeEntityId, encodeEntityId } from "../../util/navigation_utils";
+
+/**
+ * Internal helpers used by `useDataSourceTableController` to persist the state of a
+ * collection table (filters, sort and text search) in the URL query string.
+ *
+ * These functions are intentionally NOT re-exported by the package barrel files:
+ * they are pure and live in their own module only so that they can be unit tested.
+ * `encodeFilterAndSort` and `parseFilterAndSort` must stay exact inverses of each
+ * other, otherwise state written to the URL is silently dropped on reload.
+ */
+
+/**
+ * Serialise the state of a collection table into a URL query string,
+ * without the leading `?`. Returns an empty string when there is no state to persist.
+ */
+export function encodeFilterAndSort(filterValues?: FilterValues<string>,
+                                    sortBy?: [string, "asc" | "desc"] | undefined,
+                                    searchString?: string) {
+    const entries: Record<string, string> = {};
+    if (sortBy) {
+        entries["__sort"] = encodeURIComponent(sortBy[0]);
+        entries["__sort_order"] = encodeURIComponent(sortBy[1]);
+    }
+    if (filterValues) {
+        Object.entries(filterValues).forEach(([key, value]) => {
+            if (value) {
+                const [op, val] = value;
+                let encodedValue: any = val;
+                try {
+                    if (typeof val === "object") {
+                        if (val instanceof Date) {
+                            encodedValue = val.toISOString();
+                        } else if (Array.isArray(val)) {
+                            encodedValue = JSON.stringify(val, (key, value) => {
+                                if (value instanceof EntityReference) {
+                                    return encodeRef(value);
+                                }
+                                return value;
+                            });
+                        } else if (val instanceof EntityReference) {
+                            encodedValue = encodeRef(val);
+                        }
+                    } else if (typeof val === "string") {
+                        // JSON.stringify wraps the string in quotes (e.g. "4" → '"4"')
+                        // so that decodeString's JSON.parse restores the string type,
+                        // not a number. Without this, "4" round-trips as the number 4.
+                        encodedValue = JSON.stringify(val);
+                    }
+                } catch (e) {
+                    encodedValue = val;
+                }
+                if (encodedValue !== undefined) {
+                    entries[encodeURIComponent(`${key}_op`)] = encodeURIComponent(op);
+                    // Note: check for null/undefined explicitly instead of truthiness,
+                    // otherwise falsy-but-valid values (boolean `false`, number `0`)
+                    // would be serialized as "null" and round-trip back as `null`,
+                    // breaking filters like `archived == false`.
+                    entries[encodeURIComponent(`${key}_value`)] = encodedValue !== null && encodedValue !== undefined
+                        ? encodeURIComponent(encodedValue.toString())
+                        : "null";
+                }
+            }
+        });
+    }
+    // The text search term is encoded once here; `parseFilterAndSort` reads it back with
+    // `URLSearchParams`, which decodes exactly once. Do NOT decode it a second time or
+    // terms containing a literal `%` (e.g. "50%") would throw a URIError.
+    if (searchString) {
+        entries["search"] = encodeURIComponent(searchString);
+    }
+    if (!Object.keys(entries).length) {
+        return "";
+    }
+    return Object.entries(entries).map(([key, value]) => `${key}=${value}`).join("&");
+}
+
+/**
+ * Restore the state of a collection table from a URL query string.
+ * The inverse of {@link encodeFilterAndSort}.
+ */
+export function parseFilterAndSort<M>(search: string): {
+    filterValues: FilterValues<string> | undefined,
+    sortBy?: [Extract<keyof M, string>, "asc" | "desc"],
+    searchString?: string
+} {
+    const entries = new URLSearchParams(search);
+    const filterValues: FilterValues<string> = {};
+    let sortBy: [string, "asc" | "desc"] | undefined = undefined;
+    entries.forEach((value, key) => {
+        if (key === "__sort") {
+            sortBy = [decodeURIComponent(value), entries.get("__sort_order") as "asc" | "desc"];
+        } else if (key.endsWith("_op")) {
+            const field = key.replace("_op", "");
+            const filterOp = decodeURIComponent(value) as WhereFilterOp;
+            const filterValStr = entries.get(`${field}_value`);
+            if (filterValStr !== null) {
+                filterValues[field] = [filterOp, decodeString(filterValStr)];
+            }
+        }
+    });
+
+    // `URLSearchParams` has already percent-decoded the value, so it is used as is.
+    const searchString = entries.get("search") ?? undefined;
+
+    return {
+        filterValues: Object.keys(filterValues).length ? filterValues : undefined,
+        sortBy,
+        searchString: searchString ? searchString : undefined
+    }
+}
+
+function isDate(dateString: string): boolean {
+    // Define a regex pattern that matches the exact date format: 2025-01-07T23:00:00.000Z
+    const regexPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+    // Test the dateString against the regex pattern
+    if (!regexPattern.test(dateString)) {
+        return false;
+    }
+
+    // If the regex matches, further validate if it is a valid UTC date
+    const date = new Date(dateString);
+    return date.toISOString() === dateString;
+}
+
+function encodeRef(val: EntityReference) {
+    return `ref::${val.path}/${encodeEntityId(val.id)}`;
+}
+
+/**
+ * Split a "path/id" reference on its LAST separator: the path may itself be a
+ * subcollection path with several segments, and the id is escaped so it is always exactly
+ * one segment.
+ */
+function decodeRef(encoded: string): EntityReference {
+    const separatorIndex = encoded.lastIndexOf("/");
+    if (separatorIndex < 0) return new EntityReference(encoded, "");
+    return new EntityReference(
+        decodeEntityId(encoded.substring(separatorIndex + 1)),
+        encoded.substring(0, separatorIndex)
+    );
+}
+
+function decodeString(val: string): EntityReference | Date | string {
+    let parsedFilterVal: any = val;
+    if (isDate(val)) {
+        try {
+            parsedFilterVal = new Date(val);
+        } catch (e) {
+            // ignore
+        }
+    }
+    if (typeof parsedFilterVal === "string") {
+        try {
+            parsedFilterVal = JSON.parse(parsedFilterVal, (key, value) => {
+                if (typeof value === "string" && value.startsWith("ref::")) {
+                    return decodeRef(value.substring(5));
+                }
+                return value;
+            });
+        } catch (e) {
+            // ignore
+        }
+    }
+
+    if (typeof parsedFilterVal === "string" && parsedFilterVal.startsWith("ref::")) {
+        return decodeRef(parsedFilterVal.substring(5));
+    }
+    return parsedFilterVal;
+}

--- a/packages/firecms_core/src/components/common/useDataSourceTableController.tsx
+++ b/packages/firecms_core/src/components/common/useDataSourceTableController.tsx
@@ -7,18 +7,16 @@ import {
     DataType,
     Entity,
     EntityCollection,
-    EntityReference,
     EntityTableController,
     FilterValues,
     FireCMSContext,
     SelectedCellProps,
-    User,
-    WhereFilterOp
+    User
 } from "../../types";
 import { useDebouncedData } from "./useDebouncedData";
 import { ScrollRestorationController } from "./useScrollRestoration";
 import { isDataTypeFilterable } from "../../util";
-import { decodeEntityId, encodeEntityId } from "../../util/navigation_utils";
+import { encodeFilterAndSort, parseFilterAndSort } from "./table_url_params";
 
 const DEFAULT_PAGE_SIZE = 50;
 
@@ -95,8 +93,6 @@ export function useDataSourceTableController<M extends Record<string, any> = any
     const paginationEnabled = collection.pagination === undefined || Boolean(collection.pagination);
     const pageSize = typeof collection.pagination === "number" ? collection.pagination : DEFAULT_PAGE_SIZE;
 
-    const [searchString, setSearchString] = React.useState<string | undefined>();
-
     const checkFilterCombination = useCallback((filterValues: FilterValues<any>,
         sortBy?: [string, "asc" | "desc"]) => {
         if (!dataSource.isFilterCombinationValid)
@@ -137,8 +133,9 @@ export function useDataSourceTableController<M extends Record<string, any> = any
     const {
         filterValues: initialFilterUrl,
         sortBy: initialSortUrl,
+        searchString: initialSearchUrl
     } = parseFilterAndSort(location.search);
-    
+
     const availableFilterKeys = collection.allowedFilters ?? Object.keys(collection.properties);
     const forcedFilterKeys = collection.forceFilter ? Object.keys(collection.forceFilter) : [];
 
@@ -174,6 +171,11 @@ export function useDataSourceTableController<M extends Record<string, any> = any
 
     const [filterValues, setFilterValues] = React.useState<FilterValues<Extract<keyof M, string>> | undefined>(removeUnallowedFilters(initFilters));
     const [sortBy, setSortBy] = React.useState<[Extract<keyof M, string>, "asc" | "desc"] | undefined>((updateUrl ? initialSortUrl : undefined) ?? initialSortInternal);
+    // Like the filters and the sort, the text search term is only restored from the URL when
+    // this controller owns the URL. Controllers rendered inside a dialog (e.g. a reference
+    // selection dialog) get `updateUrl: false` and must not inherit the state of the
+    // collection behind them. See https://github.com/firecmsco/firecms/issues/702
+    const [searchString, setSearchString] = React.useState<string | undefined>(updateUrl ? initialSearchUrl : undefined);
 
     useUpdateUrl(filterValues, sortBy, searchString, updateUrl);
 
@@ -253,32 +255,43 @@ export function useDataSourceTableController<M extends Record<string, any> = any
             setDataLoadingError(error);
         };
 
-        if (dataSource.listenCollection) {
-            return dataSource.listenCollection<M>({
-                path: resolvedPath,
-                collection,
-                onUpdate: onEntitiesUpdate,
-                onError,
-                searchString,
-                filter: filterValues,
-                limit: itemCount,
-                startAfter: undefined,
-                orderBy: sortByProperty,
-                order: currentSort
-            });
-        } else {
-            dataSource.fetchCollection<M>({
-                path: resolvedPath,
-                collection,
-                searchString,
-                filter: filterValues,
-                limit: itemCount,
-                startAfter: undefined,
-                orderBy: sortByProperty,
-                order: currentSort
-            })
-                .then(onEntitiesUpdate)
-                .catch(onError);
+        // Data sources may throw synchronously, e.g. when a text search is requested before
+        // the text search backend of the collection has been initialised. That can happen
+        // when the search term is restored from the URL instead of typed in the search bar,
+        // so it is reported as a data loading error rather than being left to blow up the
+        // whole view from inside this effect.
+        try {
+            if (dataSource.listenCollection) {
+                return dataSource.listenCollection<M>({
+                    path: resolvedPath,
+                    collection,
+                    onUpdate: onEntitiesUpdate,
+                    onError,
+                    searchString,
+                    filter: filterValues,
+                    limit: itemCount,
+                    startAfter: undefined,
+                    orderBy: sortByProperty,
+                    order: currentSort
+                });
+            } else {
+                dataSource.fetchCollection<M>({
+                    path: resolvedPath,
+                    collection,
+                    searchString,
+                    filter: filterValues,
+                    limit: itemCount,
+                    startAfter: undefined,
+                    orderBy: sortByProperty,
+                    order: currentSort
+                })
+                    .then(onEntitiesUpdate)
+                    .catch(onError);
+                return () => {
+                };
+            }
+        } catch (e: any) {
+            onError(e instanceof Error ? e : new Error(String(e)));
             return () => {
             };
         }
@@ -332,9 +345,7 @@ function useUpdateUrl<M extends Record<string, any> = any>(
 
     useEffect(() => {
         if (updateUrl) {
-            const newUrl = encodeFilterAndSort(filterValues, sortBy);
-            const search = searchString ? `&search=${encodeURIComponent(searchString)}` : "";
-            const state = `${newUrl}${search}`;
+            const state = encodeFilterAndSort(filterValues, sortBy, searchString);
             const hash = window.location.hash;
             if (state === "")
                 window.history.replaceState({}, "", `${window.location.pathname}${hash}`);
@@ -342,143 +353,4 @@ function useUpdateUrl<M extends Record<string, any> = any>(
                 window.history.replaceState({}, "", `?${state}${hash}`);
         }
     }, [filterValues, sortBy, searchString, updateUrl]);
-}
-
-function encodeFilterAndSort(filterValues?: FilterValues<string>, sortBy?: [string, "asc" | "desc"] | undefined) {
-    const entries: Record<string, string> = {};
-    if (sortBy) {
-        entries["__sort"] = encodeURIComponent(sortBy[0]);
-        entries["__sort_order"] = encodeURIComponent(sortBy[1]);
-    }
-    if (filterValues) {
-        Object.entries(filterValues).forEach(([key, value]) => {
-            if (value) {
-                const [op, val] = value;
-                let encodedValue: any = val;
-                try {
-                    if (typeof val === "object") {
-                        if (val instanceof Date) {
-                            encodedValue = val.toISOString();
-                        } else if (Array.isArray(val)) {
-                            encodedValue = JSON.stringify(val, (key, value) => {
-                                if (value instanceof EntityReference) {
-                                    return encodeRef(value);
-                                }
-                                return value;
-                            });
-                        } else if (val instanceof EntityReference) {
-                            encodedValue = encodeRef(val);
-                        }
-                    } else if (typeof val === "string") {
-                        // JSON.stringify wraps the string in quotes (e.g. "4" → '"4"')
-                        // so that decodeString's JSON.parse restores the string type,
-                        // not a number. Without this, "4" round-trips as the number 4.
-                        encodedValue = JSON.stringify(val);
-                    }
-                } catch (e) {
-                    encodedValue = val;
-                }
-                if (encodedValue !== undefined) {
-                    entries[encodeURIComponent(`${key}_op`)] = encodeURIComponent(op);
-                    // Note: check for null/undefined explicitly instead of truthiness,
-                    // otherwise falsy-but-valid values (boolean `false`, number `0`)
-                    // would be serialized as "null" and round-trip back as `null`,
-                    // breaking filters like `archived == false`.
-                    entries[encodeURIComponent(`${key}_value`)] = encodedValue !== null && encodedValue !== undefined
-                        ? encodeURIComponent(encodedValue.toString())
-                        : "null";
-                }
-            }
-        });
-    }
-    if (!Object.keys(entries).length) {
-        return "";
-    }
-    return Object.entries(entries).map(([key, value]) => `${key}=${value}`).join("&");
-}
-
-function parseFilterAndSort<M>(search: string): {
-    filterValues: FilterValues<string> | undefined,
-    sortBy?: [Extract<keyof M, string>, "asc" | "desc"]
-} {
-    const entries = new URLSearchParams(search);
-    const filterValues: FilterValues<string> = {};
-    let sortBy: [string, "asc" | "desc"] | undefined = undefined;
-    entries.forEach((value, key) => {
-        if (key === "__sort") {
-            sortBy = [decodeURIComponent(value), entries.get("__sort_order") as "asc" | "desc"];
-        } else if (key.endsWith("_op")) {
-            const field = key.replace("_op", "");
-            const filterOp = decodeURIComponent(value) as WhereFilterOp;
-            const filterValStr = entries.get(`${field}_value`);
-            if (filterValStr !== null) {
-                filterValues[field] = [filterOp, decodeString(filterValStr)];
-            }
-        }
-    });
-
-    return {
-        filterValues: Object.keys(filterValues).length ? filterValues : undefined,
-        sortBy
-    }
-}
-
-function isDate(dateString: string): boolean {
-    // Define a regex pattern that matches the exact date format: 2025-01-07T23:00:00.000Z
-    const regexPattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-
-    // Test the dateString against the regex pattern
-    if (!regexPattern.test(dateString)) {
-        return false;
-    }
-
-    // If the regex matches, further validate if it is a valid UTC date
-    const date = new Date(dateString);
-    return date.toISOString() === dateString;
-}
-
-function encodeRef(val: EntityReference) {
-    return `ref::${val.path}/${encodeEntityId(val.id)}`;
-}
-
-/**
- * Split a "path/id" reference on its LAST separator: the path may itself be a
- * subcollection path with several segments, and the id is escaped so it is always exactly
- * one segment.
- */
-function decodeRef(encoded: string): EntityReference {
-    const separatorIndex = encoded.lastIndexOf("/");
-    if (separatorIndex < 0) return new EntityReference(encoded, "");
-    return new EntityReference(
-        decodeEntityId(encoded.substring(separatorIndex + 1)),
-        encoded.substring(0, separatorIndex)
-    );
-}
-
-function decodeString(val: string): EntityReference | Date | string {
-    let parsedFilterVal: any = val;
-    if (isDate(val)) {
-        try {
-            parsedFilterVal = new Date(val);
-        } catch (e) {
-            // ignore
-        }
-    }
-    if (typeof parsedFilterVal === "string") {
-        try {
-            parsedFilterVal = JSON.parse(parsedFilterVal, (key, value) => {
-                if (typeof value === "string" && value.startsWith("ref::")) {
-                    return decodeRef(value.substring(5));
-                }
-                return value;
-            });
-        } catch (e) {
-            // ignore
-        }
-    }
-
-    if (typeof parsedFilterVal === "string" && parsedFilterVal.startsWith("ref::")) {
-        return decodeRef(parsedFilterVal.substring(5));
-    }
-    return parsedFilterVal;
 }

--- a/packages/firecms_core/src/components/common/useTableSearchHelper.ts
+++ b/packages/firecms_core/src/components/common/useTableSearchHelper.ts
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { EntityCollection } from "../../types";
 import { useCustomizationController, useDataSource, useFireCMSContext } from "../../hooks";
@@ -7,12 +7,19 @@ export interface UseTableSearchHelperParams<M extends Record<string, any>> {
     collection: EntityCollection<M>;
     fullPath: string;
     parentCollectionIds?: string[];
+    /**
+     * Search term that is already being applied without the user having gone through the
+     * search bar, e.g. one restored from the URL query params. When set, text search is
+     * initialised automatically instead of waiting for a click on the search bar.
+     */
+    initialSearchString?: string;
 }
 
 export function useTableSearchHelper<M extends Record<string, any>>({
                                                                         collection,
                                                                         fullPath,
-                                                                        parentCollectionIds
+                                                                        parentCollectionIds,
+                                                                        initialSearchString
                                                                     }: UseTableSearchHelperParams<M>) {
 
     const context = useFireCMSContext();
@@ -21,6 +28,7 @@ export function useTableSearchHelper<M extends Record<string, any>>({
 
     const [textSearchLoading, setTextSearchLoading] = useState<boolean>(false);
     const [textSearchInitialised, setTextSearchInitialised] = useState<boolean>(false);
+    const autoInitialisedRef = useRef<boolean>(false);
 
     let onTextSearchClick: (() => void) | undefined;
     let textSearchEnabled = Boolean(collection.textSearchEnabled);
@@ -79,6 +87,17 @@ export function useTableSearchHelper<M extends Record<string, any>>({
                 }
         })
     }
+
+    // Only ever runs once, and only when a search term was restored from outside the search
+    // bar: otherwise the search bar would show a term the user can neither edit nor clear,
+    // because it stays read only until text search is initialised.
+    const shouldAutoInitialise = Boolean(initialSearchString) && textSearchEnabled && !textSearchInitialised && Boolean(onTextSearchClick);
+    useEffect(() => {
+        if (autoInitialisedRef.current || !shouldAutoInitialise) return;
+        autoInitialisedRef.current = true;
+        onTextSearchClick?.();
+    }, [shouldAutoInitialise]);
+
     return {
         textSearchLoading,
         textSearchInitialised,

--- a/packages/firecms_core/test/table_url_params.test.ts
+++ b/packages/firecms_core/test/table_url_params.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { encodeFilterAndSort, parseFilterAndSort } from "../src/components/common/table_url_params";
+
+/**
+ * `encodeFilterAndSort` and `parseFilterAndSort` must stay exact inverses of each other.
+ * The `search` param used to be written by `useUpdateUrl` but never read back, which made it
+ * disappear on reload. See https://github.com/firecmsco/firecms/issues/724
+ */
+describe("table url params: search term", () => {
+
+    it("encodes the search term", () => {
+        expect(encodeFilterAndSort(undefined, undefined, "inimitable")).toEqual("search=inimitable");
+    });
+
+    it("omits the search term when there is none", () => {
+        expect(encodeFilterAndSort(undefined, undefined, undefined)).toEqual("");
+        expect(encodeFilterAndSort(undefined, undefined, "")).toEqual("");
+    });
+
+    it("parses the search term", () => {
+        expect(parseFilterAndSort("?search=inimitable").searchString).toEqual("inimitable");
+    });
+
+    it("parses the search term written by previous versions with a stray ampersand", () => {
+        // `useUpdateUrl` used to concatenate "&search=..." to a possibly empty query string
+        expect(parseFilterAndSort("?&search=inimitable").searchString).toEqual("inimitable");
+    });
+
+    it("treats a missing or empty search term as undefined", () => {
+        expect(parseFilterAndSort("").searchString).toBeUndefined();
+        expect(parseFilterAndSort("?__sort=name&__sort_order=asc").searchString).toBeUndefined();
+        expect(parseFilterAndSort("?search=").searchString).toBeUndefined();
+    });
+
+    it("round-trips search terms with characters that need escaping", () => {
+        const terms = [
+            "inimitable",
+            "the great gatsby",
+            "100% pure",
+            "a&b",
+            "a+b",
+            "a=b",
+            "café",
+            "#hash",
+            "a/b?c",
+            "\"quoted\""
+        ];
+        terms.forEach((term) => {
+            const encoded = encodeFilterAndSort(undefined, undefined, term);
+            expect(parseFilterAndSort(`?${encoded}`).searchString).toEqual(term);
+        });
+    });
+
+    it("round-trips the search term together with sort and filters", () => {
+        const filterValues = { name: ["==", "Dune"] } as const;
+        const sortBy: [string, "asc" | "desc"] = ["name", "desc"];
+
+        const encoded = encodeFilterAndSort(filterValues as any, sortBy, "inimitable");
+        const parsed = parseFilterAndSort(`?${encoded}`);
+
+        expect(parsed.searchString).toEqual("inimitable");
+        expect(parsed.sortBy).toEqual(["name", "desc"]);
+        expect(parsed.filterValues).toEqual({ name: ["==", "Dune"] });
+    });
+
+    it("does not confuse the search term with a property called `search`", () => {
+        const encoded = encodeFilterAndSort({ search: ["==", "engine"] } as any, undefined, "inimitable");
+        const parsed = parseFilterAndSort(`?${encoded}`);
+
+        expect(parsed.searchString).toEqual("inimitable");
+        expect(parsed.filterValues).toEqual({ search: ["==", "engine"] });
+    });
+
+    it("keeps sort and filters untouched when there is no search term", () => {
+        const encoded = encodeFilterAndSort({ archived: ["==", false] } as any, ["name", "asc"], undefined);
+        const parsed = parseFilterAndSort(`?${encoded}`);
+
+        expect(encoded).not.toContain("search");
+        expect(parsed.sortBy).toEqual(["name", "asc"]);
+        expect(parsed.filterValues).toEqual({ archived: ["==", false] });
+        expect(parsed.searchString).toBeUndefined();
+    });
+
+});

--- a/packages/ui/src/components/SearchBar.tsx
+++ b/packages/ui/src/components/SearchBar.tsx
@@ -11,6 +11,13 @@ interface SearchBarProps {
     onClick?: () => void;
     onTextSearch?: (searchString?: string) => void;
     placeholder?: string;
+    /**
+     * Text the input is initialised with. Use it when the search term is restored from
+     * somewhere else, e.g. a URL query parameter, so that the input reflects the search
+     * that is actually being applied. Only read when the component mounts; the search bar
+     * owns the text from then on.
+     */
+    initialValue?: string;
     expandable?: boolean;
     /**
      * Size of the search bar.
@@ -35,6 +42,7 @@ export function SearchBar({
     onClick,
     onTextSearch,
     placeholder = "Search",
+    initialValue,
     expandable = false,
     size = "medium",
     large,
@@ -46,7 +54,7 @@ export function SearchBar({
     inputRef
 }: SearchBarProps) {
 
-    const [searchText, setSearchText] = useState<string>("");
+    const [searchText, setSearchText] = useState<string>(initialValue ?? "");
     const [active, setActive] = useState<boolean>(false);
 
     const deferredValues = useDebounceValue(searchText, 200);


### PR DESCRIPTION
Fixes #724

## The bug
Two halves, both in `useDataSourceTableController`:

1. **Write-only param.** `useUpdateUrl` serialised `&search=<term>` into the URL, but `parseFilterAndSort` only matched `__sort`, `__sort_order` and `*_op`/`*_value`. Nothing ever read `search` back.
2. **Actively destroyed.** `searchString` started `undefined`, so the first `history.replaceState` wrote a query string *without* it — which is why the param visibly disappeared rather than merely being ignored.

Reproduced side by side:
```
BEFORE  incoming URL: /c/books?search=inimitable
BEFORE  seeded state: undefined
BEFORE  URL after 1st replaceState: /c/books          <-- param destroyed
AFTER   parsed: {"searchString":"inimitable"}
AFTER   URL after 1st replaceState: ?search=inimitable
```

## The fix
`encodeFilterAndSort`/`parseFilterAndSort` are extracted into a new `table_url_params.ts` (a module no barrel re-exports, so it is testable without widening the public API), `search` now round-trips, and `initialSearchString` is threaded through `useTableSearchHelper` → `EntityCollectionView` → `CollectionTableToolbar` → `SearchBar`.

## #702 is not regressed
`a627f1d1e` fixed reference dialogs inheriting the parent collection's sort/filter from the URL, via the `updateUrl` gate. The identical gate is applied here:

```ts
useState(updateUrl ? initialSearchUrl : undefined)   // matches filters and sort exactly
```

A dialog controller (`updateUrl: false`) therefore still neither reads nor writes the URL. `initialSearchString` is also deliberately not passed in `ReferenceSelectionTable`, so the auto-init cannot fire there.

## Two extras found while making encode/parse symmetric
- The existing `__sort` path **double-decodes** (`URLSearchParams` *and* `decodeURIComponent`), which would throw `URIError` on a term like `100%` — so `search` is read back without the second decode.
- The old string concatenation emitted a stray `?&search=x` when there was no filter/sort. Fixed, with the legacy form still parsing (tested).

## Tests
9 round-trip tests, including escaping, combined sort+filter+search, the legacy stray-ampersand form, and not confusing a property literally named `search`.

`@firecms/core`: 246/249 passing (was 237/240) — 3 pre-existing failures unchanged.

## ⚠️ Known limitation, disclosed rather than hidden
If a datasource's `search()` requires a prior `init()` — the local Fuse controller throws `Index not found for path X` — the first fetch races the auto-init, and the fetch effect's deps don't include text-search readiness, so it won't refetch when init resolves. **A deep link can therefore land on an empty table until the user edits the term.** The Typesense/FireCMS controller self-initialises inside `search()` and is unaffected. A try/catch guarantees no crash either way.

Fixing this properly means moving ownership of `textSearchInitialised` between `useDataSourceTableController` and `useTableSearchHelper` — a restructure judged out of scope for this fix.

## Not verified
Whether the search box visually renders the restored term needs a browser; the mechanism is a one-line state seed but is unexercised at runtime. Real Firestore/Typesense deep-link behaviour also untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
