### PR TITLE
fix(data_export): make collection export respect the active filter and sort

### DIFF
--- a/packages/data_export/src/export/ExportCollectionAction.tsx
+++ b/packages/data_export/src/export/ExportCollectionAction.tsx
@@ -5,6 +5,7 @@ import {
     Entity,
     EntityCollection,
     ExportConfig,
+    FilterValues,
     getDefaultValuesFor,
     resolveCollection,
     ResolvedEntityCollection,
@@ -34,10 +35,63 @@ import { downloadEntitiesExport } from "./export";
 
 const DOCS_LIMIT = 500;
 
+type ExportFilterAndSortParams<M extends Record<string, any>> = {
+    filterValues?: FilterValues<Extract<keyof M, string>>;
+    sortBy?: [Extract<keyof M, string>, "asc" | "desc"];
+    forceFilter?: FilterValues<Extract<keyof M, string>>;
+};
+
+/**
+ * A filter forced by the collection config always applies to the data the user
+ * is allowed to see, so it is not something they can opt out of when exporting.
+ * The toggle is therefore only worth showing when there is a filter the user
+ * applied themselves, or an active sort.
+ */
+function hasUserFilterOrSort<M extends Record<string, any>>({
+    filterValues,
+    sortBy,
+    forceFilter
+}: ExportFilterAndSortParams<M>): boolean {
+    if (sortBy) return true;
+    if (!filterValues) return false;
+    const forcedKeys = forceFilter ? Object.keys(forceFilter) : [];
+    return Object.keys(filterValues).some((key) => !forcedKeys.includes(key));
+}
+
+/**
+ * Build the `filter`, `orderBy` and `order` params passed to `fetchCollection`
+ * when exporting.
+ *
+ * `forceFilter` is a data scoping constraint rather than a user preference, so it
+ * is always applied, and it takes precedence over the filter values coming from
+ * the table controller (same precedence used by the filters dialog).
+ */
+function resolveExportFilterAndSort<M extends Record<string, any>>({
+    applyFilterAndSort,
+    filterValues,
+    sortBy,
+    forceFilter
+}: ExportFilterAndSortParams<M> & { applyFilterAndSort: boolean }): {
+    filter?: FilterValues<Extract<keyof M, string>>;
+    orderBy?: string;
+    order?: "asc" | "desc";
+} {
+    const filter = {
+        ...(applyFilterAndSort ? filterValues : undefined),
+        ...forceFilter
+    } as FilterValues<Extract<keyof M, string>>;
+    return {
+        filter: Object.keys(filter).length > 0 ? filter : undefined,
+        orderBy: applyFilterAndSort ? sortBy?.[0] : undefined,
+        order: applyFilterAndSort ? sortBy?.[1] : undefined
+    };
+}
+
 export function ExportCollectionAction<M extends Record<string, any>, USER extends User>({
     collection: inputCollection,
     path: inputPath,
     collectionEntitiesCount,
+    tableController,
     onAnalyticsEvent,
     exportAllowed,
     notAllowedView
@@ -57,6 +111,18 @@ export function ExportCollectionAction<M extends Record<string, any>, USER exten
     const [flattenArrays, setFlattenArrays] = React.useState<boolean>(true);
     const [exportType, setExportType] = React.useState<"csv" | "json">("csv");
     const [dateExportType, setDateExportType] = React.useState<"timestamp" | "string">("string");
+    const [applyFilterAndSort, setApplyFilterAndSort] = React.useState<boolean>(true);
+
+    // the filter and sort currently applied in the collection view
+    const filterValues = tableController?.filterValues;
+    const sortBy = tableController?.sortBy;
+    const forceFilter = inputCollection.forceFilter;
+
+    const filterOrSortActive = React.useMemo(() => hasUserFilterOrSort<M>({
+        filterValues,
+        sortBy,
+        forceFilter
+    }), [filterValues, sortBy, forceFilter]);
 
     const authController = useAuthController();
     const { t } = useTranslation();
@@ -135,9 +201,24 @@ export function ExportCollectionAction<M extends Record<string, any>, USER exten
             collection: collection.path
         });
         setDataLoading(true);
+
+        const {
+            filter,
+            orderBy,
+            order
+        } = resolveExportFilterAndSort<M>({
+            applyFilterAndSort: filterOrSortActive && applyFilterAndSort,
+            filterValues,
+            sortBy,
+            forceFilter
+        });
+
         dataSource.fetchCollection<M>({
             path,
-            collection
+            collection,
+            filter,
+            orderBy,
+            order
         })
             .then(async (data) => {
                 setDataLoadingError(undefined);
@@ -177,7 +258,7 @@ export function ExportCollectionAction<M extends Record<string, any>, USER exten
             })
             .finally(() => setDataLoading(false));
 
-    }, [onAnalyticsEvent, dataSource, path, fetchAdditionalFields, includeUndefinedValues, flattenArrays, exportType, dateExportType]);
+    }, [onAnalyticsEvent, dataSource, path, fetchAdditionalFields, includeUndefinedValues, flattenArrays, exportType, dateExportType, filterOrSortActive, applyFilterAndSort, filterValues, sortBy, forceFilter]);
 
     const onOkClicked = useCallback(() => {
         doDownload(collection, exportConfig);
@@ -253,6 +334,12 @@ export function ExportCollectionAction<M extends Record<string, any>, USER exten
                         </div>
                     </div>
                 </div>
+
+                {filterOrSortActive && <BooleanSwitchWithLabel
+                    size={"small"}
+                    value={applyFilterAndSort}
+                    onValueChange={setApplyFilterAndSort}
+                    label={t("export_apply_filter_sort")} />}
 
                 <BooleanSwitchWithLabel
                     size={"small"}

--- a/packages/firecms_core/src/locales/de.ts
+++ b/packages/firecms_core/src/locales/de.ts
@@ -389,6 +389,7 @@ export const de: FireCMSTranslations = {
     download: "Herunterladen",
     large_number_of_documents: "Diese Sammlung hat eine große Anzahl von Dokumenten ({{count}}).",
     include_undefined_values: "Undefinierte Werte einschließen",
+    export_apply_filter_sort: "Nur Ergebnisse exportieren, die dem aktuellen Filter/der aktuellen Sortierung entsprechen",
     submit: "Einreichen",
 
     no_filterable_properties: "Keine filterbaren Eigenschaften verfügbar",

--- a/packages/firecms_core/src/locales/en.ts
+++ b/packages/firecms_core/src/locales/en.ts
@@ -397,6 +397,7 @@ export const en: FireCMSTranslations = {
     download: "Download",
     large_number_of_documents: "This collections has a large number of documents ({{count}}).",
     include_undefined_values: "Include undefined values",
+    export_apply_filter_sort: "Only export results matching the current filter/sort",
     submit: "Submit",
 
     no_filterable_properties: "No filterable properties available",

--- a/packages/firecms_core/src/locales/es.ts
+++ b/packages/firecms_core/src/locales/es.ts
@@ -397,6 +397,7 @@ export const es: FireCMSTranslations = {
     download: "Descargar",
     large_number_of_documents: "Esta colección posee un gran número de documentos ({{count}}).",
     include_undefined_values: "Incluir valores omitidos (undefined)",
+    export_apply_filter_sort: "Exportar solo los resultados que coinciden con el filtro/orden actual",
     submit: "Enviar",
 
     no_filterable_properties: "No hay propiedades filtrables disponibles",

--- a/packages/firecms_core/src/locales/fr.ts
+++ b/packages/firecms_core/src/locales/fr.ts
@@ -389,6 +389,7 @@ export const fr: FireCMSTranslations = {
     download: "Télécharger",
     large_number_of_documents: "Cette collection contient un grand nombre de documents ({{count}}).",
     include_undefined_values: "Inclure les valeurs non définies",
+    export_apply_filter_sort: "N'exporter que les résultats correspondant au filtre/tri actuel",
     submit: "Soumettre",
 
     no_filterable_properties: "Aucune propriété filtrable disponible",

--- a/packages/firecms_core/src/locales/hi.ts
+++ b/packages/firecms_core/src/locales/hi.ts
@@ -389,6 +389,7 @@ export const hi: FireCMSTranslations = {
     download: "डाउनलोड",
     large_number_of_documents: "इस संग्रह में बड़ी संख्या में दस्तावेज़ हैं ({{count}})।",
     include_undefined_values: "अपरिभाषित (undefined) मान शामिल करें",
+    export_apply_filter_sort: "केवल वर्तमान फ़िल्टर/सॉर्ट से मेल खाने वाले परिणाम निर्यात करें",
     submit: "सबमिट करें",
 
     no_filterable_properties: "कोई फ़िल्टर करने योग्य गुण उपलब्ध नहीं हैं",

--- a/packages/firecms_core/src/locales/it.ts
+++ b/packages/firecms_core/src/locales/it.ts
@@ -389,6 +389,7 @@ export const it: FireCMSTranslations = {
     download: "Scarica",
     large_number_of_documents: "Questa collezione contiene un numero elevato di documenti ({{count}})",
     include_undefined_values: "Includi valori non definiti",
+    export_apply_filter_sort: "Esporta solo i risultati che corrispondono al filtro/ordinamento attuale",
     submit: "Invia",
 
     no_filterable_properties: "Nessuna proprietà filtrabile disponibile",

--- a/packages/firecms_core/src/locales/pl.ts
+++ b/packages/firecms_core/src/locales/pl.ts
@@ -389,6 +389,7 @@ export const pl: FireCMSTranslations = {
     download: "Pobierz",
     large_number_of_documents: "Ta kolekcja zawiera dużą liczbę dokumentów ({{count}}).",
     include_undefined_values: "Uwzględnij niezdefiniowane wartości",
+    export_apply_filter_sort: "Eksportuj tylko wyniki zgodne z aktualnym filtrem/sortowaniem",
     submit: "Wyślij",
 
     no_filterable_properties: "Brak dostępnych właściwości do filtrowania",

--- a/packages/firecms_core/src/locales/pt.ts
+++ b/packages/firecms_core/src/locales/pt.ts
@@ -394,6 +394,7 @@ export const pt: FireCMSTranslations = {
     download: "Descarregar",
     large_number_of_documents: "Esta coleção tem um grande número de documentos ({{count}}).",
     include_undefined_values: "Incluir valores indefinidos",
+    export_apply_filter_sort: "Exportar apenas os resultados que correspondem ao filtro/ordenação atual",
     submit: "Submeter",
 
     no_filterable_properties: "Não há propriedades filtráveis disponíveis",

--- a/packages/firecms_core/src/types/translations.ts
+++ b/packages/firecms_core/src/types/translations.ts
@@ -419,6 +419,8 @@ export interface FireCMSTranslations {
     download: string;
     large_number_of_documents: string;
     include_undefined_values: string;
+    /** Toggle in the export dialog, only shown when a filter or sort is active */
+    export_apply_filter_sort: string;
     submit: string;
 
     no_filterable_properties: string;


### PR DESCRIPTION
Fixes #297 — open since 2022.

## The gap
`doDownload` called `dataSource.fetchCollection({ path, collection })` with no `filter`, `orderBy` or `order`, so exports always returned the whole collection regardless of what the user was looking at. The plumbing already existed: `FetchCollectionProps` accepts those, and this component already receives `tableController` (which exposes `filterValues` and `sortBy`) via `CollectionActionsProps`.

## UX decision
One opt-out switch, **default ON**: *"Only export results matching the current filter/sort"*.

- **Shown only when there is something to opt out of** — a filter the user set themselves, or an active sort. Unfiltered collections see an unchanged dialog.
- Silently changing 4-year-old behaviour could surprise anyone relying on a full export, hence the visible toggle rather than a silent switch.
- Wording reuses the repo's existing "filter/sort" phrasing (`clear_filter_sort`, `no_results_filter_sort`) instead of inventing terminology, and covers the filter-only and sort-only cases with one string.
- Placed with the other `BooleanSwitchWithLabel` switches, same component and props shape.

## `forceFilter`
Checked first, and it matters: `useDataSourceTableController` already seeds `filterValues` *from* `forceFilter` and refuses user changes while it's set, so `tableController.filterValues` already contains it. Handling:
- `forceFilter` is spread in **unconditionally, after** the controller's values, so it always wins — matching `FiltersDialog.tsx`.
- Forced keys are **excluded** when deciding whether to show the switch, so a collection whose only filter is forced doesn't get a pointless toggle.
- Net: toggling off gives `forceFilter` only; toggling on gives user filter + `forceFilter`.

## `searchString` — deliberately not covered, and here's why
The Firestore delegate's `fetchCollection` destructures `searchString`, **documents it in JSDoc, and then never passes it to `buildQuery`**. Text search is implemented only in `listenCollection` via `performTextSearch`. Wiring it into the export would silently do nothing.

**So a known remaining limitation: exporting while a text search is active still exports the unsearched set.** That's a separate latent issue worth its own ticket (adjacent to #322/#571), not something to paper over here.

## i18n
Every locale file is typed `FireCMSTranslations` (not partial), so the new key had to be added to all **8** core locales — and the `label` prop is covered by the repo's `i18next/no-literal-string` rule, so a bare literal wasn't an option. The guarantee was mutation-tested: deleting the key from `pl.ts` alone makes `tsc` fail with TS2741.

## Verification
`pnpm --filter @firecms/data_export build` exits 0 (after rebuilding `@firecms/core`, whose checked-in `dist` on `main` is stale — a pre-existing condition, untouched here).

`BasicExportAction.tsx` needs no change: it receives already-materialised data and has no `fetchCollection` call.

## Gap
The two extracted helpers (`hasUserFilterOrSort`, `resolveExportFilterAndSort`) are pure and trivially testable but module-private and uncovered. Jest *is* already configured in `data_export`, so a spec would be cheap — the helpers just need exporting. The dialog rendering and the actual filtered download are unverified at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
