### PR TITLE
feat(website): put a Cloud CTA on every docs page, not 10

### DIFF
--- a/website-astro/src/components/starlight/DocsCTA.astro
+++ b/website-astro/src/components/starlight/DocsCTA.astro
@@ -1,0 +1,153 @@
+---
+import Icon from "../Icon.astro";
+import { getLangFromUrl, useTranslations, useTranslatedPath } from "../../i18n/utils";
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+const translatePath = useTranslatedPath(lang);
+
+// `ref` lands in the auto-fired `go_to_app` event label (see scripts/enhance-app-links.js),
+// so clicks from this block can be told apart from the header button in GA4.
+const appHref = "https://app.firecms.co/?ref=docs_cta";
+const quickstartHref = translatePath("/docs/cloud/quickstart/");
+---
+
+<aside class="docs-cta print:hidden" data-pagefind-ignore>
+    <div class="docs-cta__text">
+        <h2 class="docs-cta__title">{t("docs.cta.title")}</h2>
+        <p class="docs-cta__body">{t("docs.cta.body")}</p>
+    </div>
+    <div class="docs-cta__actions">
+        <a class="docs-cta__button"
+           href={appHref}
+           target="_blank"
+           rel="noopener noreferrer">
+            {t("docs.cta.button")}
+            <Icon name="arrow-right" class="docs-cta__icon"/>
+        </a>
+        <a class="docs-cta__secondary" href={quickstartHref}>
+            {t("docs.cta.quickstart")}
+        </a>
+    </div>
+</aside>
+
+<style>
+    .docs-cta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1.5rem 2rem;
+        max-width: 60rem;
+        margin: 4rem auto 3rem;
+        padding: 1.75rem 1.75rem;
+        border: 1px solid var(--sl-color-gray-5);
+        border-radius: 0.75rem;
+        background:
+            linear-gradient(120deg,
+                color-mix(in oklab, var(--color-primary) 16%, transparent),
+                transparent 62%),
+            var(--sl-color-gray-6);
+    }
+
+    .docs-cta__text {
+        flex: 1 1 22rem;
+        min-width: 0;
+    }
+
+    .docs-cta__title {
+        margin: 0;
+        font-size: 1.2rem;
+        font-weight: 600;
+        line-height: 1.25;
+        color: var(--sl-color-white);
+        text-wrap: balance;
+    }
+
+    .docs-cta__body {
+        margin: 0.5rem 0 0;
+        font-size: 0.9375rem;
+        line-height: 1.55;
+        color: var(--sl-color-gray-3);
+        max-width: 46ch;
+    }
+
+    .docs-cta__actions {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.6rem;
+        flex-shrink: 0;
+    }
+
+    .docs-cta__button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.7rem 1.35rem;
+        border-radius: 0.375rem;
+        background: var(--color-primary);
+        color: #fff;
+        font-size: 0.9375rem;
+        font-weight: 600;
+        text-decoration: none;
+        white-space: nowrap;
+        box-shadow: 0 1px 2px rgb(0 0 0 / 0.16);
+        transition: background-color 200ms ease, transform 200ms ease;
+    }
+
+    .docs-cta__button:hover {
+        background: var(--color-primary-dark);
+        color: #fff;
+        transform: translateY(-1px);
+    }
+
+    .docs-cta__button:focus-visible {
+        outline: 2px solid var(--color-primary-light);
+        outline-offset: 3px;
+    }
+
+    .docs-cta__icon {
+        width: 1rem;
+        height: 1rem;
+    }
+
+    .docs-cta__secondary {
+        font-size: 0.8125rem;
+        color: var(--sl-color-gray-3);
+        text-decoration: none;
+        border-bottom: 1px solid transparent;
+    }
+
+    .docs-cta__secondary:hover,
+    .docs-cta__secondary:focus-visible {
+        color: var(--sl-color-white);
+        border-bottom-color: currentColor;
+    }
+
+    @media (max-width: 50rem) {
+        .docs-cta {
+            margin: 3rem auto 2rem;
+            padding: 1.5rem 1.25rem;
+        }
+
+        .docs-cta__actions {
+            width: 100%;
+        }
+
+        .docs-cta__button {
+            width: 100%;
+            justify-content: center;
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .docs-cta__button {
+            transition: none;
+        }
+
+        .docs-cta__button:hover {
+            transform: none;
+        }
+    }
+</style>

--- a/website-astro/src/components/starlight/PageFrame.astro
+++ b/website-astro/src/components/starlight/PageFrame.astro
@@ -1,16 +1,17 @@
 ---
 import Default from '@astrojs/starlight/components/PageFrame.astro';
 import CookieBanner from "../CookieBanner.astro";
+import DocsCTA from "./DocsCTA.astro";
 ---
 
 <Default {...Astro.props}>
     <slot slot="header" name="header" />
     <slot slot="sidebar" name="sidebar" />
     <slot />
+    <DocsCTA />
     <CookieBanner />
 </Default>
 
 <script src="../../scripts/tracking-params.js"></script>
 <script src="../../scripts/enhance-app-links.js"></script>
 <script src="../../page-effects.ts"></script>
-

--- a/website-astro/src/i18n/de.ts
+++ b/website-astro/src/i18n/de.ts
@@ -693,4 +693,9 @@ export const de = {
   'nav.home': 'Startseite',
   'seo.blog.title': 'FireCMS Blog — Firebase-Tutorials & CMS-Guides',
   'seo.blog.description': 'Erfahren Sie, wie Sie Firebase Admin-Panels erstellen, Firestore-Daten verwalten und das Beste aus FireCMS herausholen. Tutorials, Anleitungen, Vergleiche und technische Artikel.',
+
+  'docs.cta.title': 'Teste es mit deinen eigenen Daten',
+  'docs.cta.body': 'Verbinde ein Firebase-Projekt und FireCMS erstellt ein Admin-Panel aus deinen Firestore-Collections. Kostenlos starten, ohne Kreditkarte.',
+  'docs.cta.button': 'FireCMS Cloud öffnen',
+  'docs.cta.quickstart': 'Oder folge dem 5-Minuten-Schnellstart',
 };

--- a/website-astro/src/i18n/en.ts
+++ b/website-astro/src/i18n/en.ts
@@ -697,4 +697,9 @@ export const en = {
 
   'seo.blog.title': 'FireCMS Blog — Firebase Tutorials & CMS Guides',
   'seo.blog.description': 'Learn how to build Firebase admin panels, manage Firestore data, and get the most out of FireCMS. Tutorials, guides, comparisons, and engineering deep dives.',
+
+  'docs.cta.title': 'Try it on your own data',
+  'docs.cta.body': 'Connect a Firebase project and FireCMS builds an admin panel from your Firestore collections. Free to start, no credit card.',
+  'docs.cta.button': 'Open FireCMS Cloud',
+  'docs.cta.quickstart': 'Or follow the 5-minute quickstart',
 };

--- a/website-astro/src/i18n/es.ts
+++ b/website-astro/src/i18n/es.ts
@@ -696,4 +696,9 @@ export const es = {
   'seo.pro.description': 'Desbloquea funcionalidades avanzadas con FireCMS PRO: editor visual de esquemas, gestión de usuarios y roles, importación/exportación avanzada y soporte prioritario para tu CMS Firebase autoalojado.',
   'seo.blog.title': 'Blog FireCMS — Tutoriales Firebase y Guías CMS',
   'seo.blog.description': 'Aprende a crear paneles admin Firebase, gestionar datos Firestore y sacar el máximo partido a FireCMS. Tutoriales, guías, comparativas y artículos técnicos.',
+
+  'docs.cta.title': 'Pruébalo con tus propios datos',
+  'docs.cta.body': 'Conecta un proyecto de Firebase y FireCMS crea un panel de administración a partir de tus colecciones de Firestore. Gratis para empezar, sin tarjeta de crédito.',
+  'docs.cta.button': 'Abrir FireCMS Cloud',
+  'docs.cta.quickstart': 'O sigue la guía rápida de 5 minutos',
 };

--- a/website-astro/src/i18n/fr.ts
+++ b/website-astro/src/i18n/fr.ts
@@ -689,4 +689,9 @@ export const fr = {
   'nav.home': 'Accueil',
   'seo.blog.title': 'Blog FireCMS — Tutoriels Firebase & Guides CMS',
   'seo.blog.description': 'Apprenez à créer des panels admin Firebase, gérer vos données Firestore et tirer le meilleur parti de FireCMS. Tutoriels, guides, comparatifs et articles techniques.',
+
+  'docs.cta.title': 'Essayez-le avec vos propres données',
+  'docs.cta.body': "Connectez un projet Firebase et FireCMS génère un panneau d'administration à partir de vos collections Firestore. Gratuit au démarrage, sans carte bancaire.",
+  'docs.cta.button': 'Ouvrir FireCMS Cloud',
+  'docs.cta.quickstart': 'Ou suivez le guide de démarrage en 5 minutes',
 };

--- a/website-astro/src/i18n/it.ts
+++ b/website-astro/src/i18n/it.ts
@@ -690,5 +690,9 @@ export const it = {
 
   'seo.pro.title': 'FireCMS PRO — CMS Firebase self-hosted',
   'seo.pro.description': 'Distribuisci un CMS Firestore premium e self-hosted con pannello admin. Editor schema visuale, importazione/esportazione dati, gestione utenti, branding personalizzato e supporto prioritario.',
-};
 
+  'docs.cta.title': 'Provalo sui tuoi dati',
+  'docs.cta.body': 'Collega un progetto Firebase e FireCMS crea un pannello di amministrazione dalle tue collection Firestore. Gratis per iniziare, senza carta di credito.',
+  'docs.cta.button': 'Apri FireCMS Cloud',
+  'docs.cta.quickstart': 'Oppure segui la guida rapida di 5 minuti',
+};

--- a/website-astro/src/i18n/pt.ts
+++ b/website-astro/src/i18n/pt.ts
@@ -596,4 +596,9 @@ export const pt = {
   'seo.blog.description': 'Aprenda a construir painéis admin Firebase, gerenciar dados no Firestore e aproveitar ao máximo o FireCMS. Tutoriais, guias, comparações e artigos técnicos aprofundados.',
   'seo.pro.title': 'FireCMS PRO — CMS Firebase Self-Hosted',
   'seo.pro.description': 'Faça deploy de um CMS Firestore e painel admin premium e self-hosted. Editor visual de schema, importação/exportação de dados, gestão de usuários, branding personalizado e suporte prioritário.',
+
+  'docs.cta.title': 'Teste com os seus próprios dados',
+  'docs.cta.body': 'Ligue um projeto Firebase e o FireCMS cria um painel de administração a partir das suas coleções do Firestore. Gratuito para começar, sem cartão de crédito.',
+  'docs.cta.button': 'Abrir o FireCMS Cloud',
+  'docs.cta.quickstart': 'Ou siga o guia rápido de 5 minutos',
 };


### PR DESCRIPTION
## Why

GA4 + Search Console, 1 May – 24 Aug 2026:

| Section | URLs | Pageviews | App clicks | Per 1,000 pv |
|---|---|---|---|---|
| Homepage (EN) | 2 | 7,185 | 1,426 | **198.5** |
| Localised marketing | 264 | 3,223 | 637 | 197.6 |
| Marketing EN (other) | 109 | 3,002 | 92 | 30.6 |
| Blog | 36 | 572 | 5 | 8.7 |
| **Docs (EN)** | 3,616 | **16,095** | **62** | **3.9** |
| **Docs (localised)** | 3,035 | **7,082** | **3** | **0.4** |

Docs are 62% of all site pageviews and have the **highest scroll rates on the site** — 37–40%, against 15.6% on the homepage. People land, read carefully, and leave, because there is nothing to click.

The only path out was the small "Start Building" button in the Starlight header. On desktop, where 98% of docs traffic sits, that converts at 2.6 per 1,000 pageviews against 160 on marketing pages. The in-content `DocsCloudCTA` that actually reads as an invitation was on 10 of 1,271 pages.

## What changed

- New `src/components/starlight/DocsCTA.astro`, rendered from `PageFrame.astro` so it lands on **every** docs page rather than being opted into per-MDX-file.
- Localised across all six locales (4 new keys × `en/es/de/fr/it/pt`), with the secondary link resolving to each locale's own quickstart.
- Links to `https://app.firecms.co/?ref=docs_cta`. `enhance-app-links.js` already instruments any `a[href*="app.firecms.co"]`, so `go_to_app` fires with no new tracking code, and the `ref` lets these clicks be separated from the header button in GA4.
- Zero-JS Astro component using Starlight's own surface tokens (`--sl-color-gray-5/6`, `--sl-color-white`), so it sits correctly on the docs' forced-dark theme and still resolves if light mode is ever restored. Respects `prefers-reduced-motion`.

## Verified against the build output

`npm run build` → 3,740 pages, clean.

- CTA present on **3,618 / 3,618** docs pages
- Present on **0** non-docs pages
- All six locale variants of the secondary link resolve to a real page (this caught a bug: `cloud_quickstart.mdx` carries a `slug:` frontmatter override, so the correct URL is `/docs/cloud/quickstart/`, not `/docs/cloud/cloud_quickstart/`)

## What to watch

Docs app-clicks per 1,000 pageviews, currently 3.9. Even a fifth of the homepage's rate is roughly +400 app visits per quarter. Filter GA4 on `ref=docs_cta` to isolate this surface from the header button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)